### PR TITLE
feat(nano-build): Add `--debug` option for improved development and fix argument formatting

### DIFF
--- a/pkg/nanolib/nano-build/README.md
+++ b/pkg/nanolib/nano-build/README.md
@@ -109,6 +109,7 @@ nano-build [flags] <entry-points>
 - `--preset=<name>` — Select a build preset (default: none)
 - `--outdir=<path>` — Output directory (default: `dist`)
 - `--watch` — Enable watch mode for development
+- `--debug` — Force development-style build (disable minify, enable sourcemaps regardless of `NODE_ENV`)
 - `--help, -h` — Show help message
 
 All other flags are forwarded to `bun build`.
@@ -204,17 +205,7 @@ NODE_ENV=production nano-build --preset=bun-service src/main.ts
 
 ### Development Mode
 
-Automatic when `NODE_ENV` is not set to `production`:
-
-- Inline sourcemaps for easier debugging
-- Preserves variable and function names
-- Disables minification
-
-**Enable explicitly:**
-
-```bash
-NODE_ENV=development nano-build --preset=module src/main.ts
-```
+Inline sourcemaps for easier debugging when `NODE_ENV` is not set to `production`.
 
 ### Production Mode
 

--- a/pkg/nanolib/nano-build/cli.sh
+++ b/pkg/nanolib/nano-build/cli.sh
@@ -66,20 +66,19 @@ for arg in "$@"; do
   esac
 done
 
-
 # default args for all presets
 args+=(
-  "--banner='/* ${banner} */'" \
-  "--outdir='${outdir}'" \
-  "--define __dev_mode__=${devMode}" \
-  "--define __package_name__='${packageName}'" \
-  "--define __package_version__='${packageVersion}'" \
+  "--banner=/* ${banner} */" \
+  "--outdir=${outdir}" \
+  --define __dev_mode__="${devMode}" \
+  --define __package_name__="'${packageName}'" \
+  --define __package_version__="'${packageVersion}'" \
 )
 
-if ! $debug; then
-  args+=('--minify')
-else
+if $debug; then
   echoColor 3 "Debug mode enabled: skipping minification and enabling linked sourcemaps.\n"
+else
+  args+=('--minify')
 fi
 
 case "$preset" in

--- a/pkg/nanolib/nano-build/cli.sh
+++ b/pkg/nanolib/nano-build/cli.sh
@@ -13,10 +13,6 @@ if ! command -v bun >/dev/null 2>&1; then
   exit 1
 fi
 
-devMode="true"
-if [[ "${NODE_ENV:-}" == "production" ]]; then
-  devMode="false"
-fi
 packageName="$(grep -o '"name": *"[^"]*"' package.json | cut -d'"' -f4)"
 packageVersion="$(grep -o '"version": *"[^"]*"' package.json | cut -d'"' -f4)"
 banner="📦 ${packageName} v${packageVersion}"
@@ -26,7 +22,12 @@ echoColor 6 "${banner}\n\n"
 
 preset=""
 outdir="dist"
+debug=false
 args=()
+devMode=true
+if [[ "${NODE_ENV:-}" == "production" ]]; then
+  devMode=false
+fi
 
 for arg in "$@"; do
   case "$arg" in
@@ -36,6 +37,11 @@ for arg in "$@"; do
 
     --outdir=*)
       outdir="${arg#--outdir=}"
+    ;;
+
+    --debug)
+      debug=true
+      devMode=true
     ;;
 
     --help|-h)
@@ -60,10 +66,25 @@ for arg in "$@"; do
   esac
 done
 
+
+# default args for all presets
+args+=(
+  "--banner='/* ${banner} */'" \
+  "--outdir='${outdir}'" \
+  "--define __dev_mode__=${devMode}" \
+  "--define __package_name__='${packageName}'" \
+  "--define __package_version__='${packageVersion}'" \
+)
+
+if ! $debug; then
+  args+=('--minify')
+else
+  echoColor 3 "Debug mode enabled: skipping minification and enabling linked sourcemaps.\n"
+fi
+
 case "$preset" in
   module)
     args+=(
-      '--minify'
       '--target=node'
       '--packages=external'
       '--sourcemap=linked'
@@ -73,33 +94,30 @@ case "$preset" in
 
   web)
     args+=(
-      '--minify'
       '--target=browser'
       '--packages=bundle'
     )
-    if [[ "$devMode" == "true" ]]; then
+    if $devMode; then
       args+=('--sourcemap=linked')
     fi
   ;;
 
   node-service)
     args+=(
-      '--minify'
       '--target=node'
       '--packages=bundle'
     )
-    if [[ "$devMode" == "true" ]]; then
+    if $devMode; then
       args+=('--sourcemap=linked')
     fi
   ;;
 
   bun-service)
     args+=(
-      '--minify'
       '--target=bun'
       '--packages=bundle'
     )
-    if [[ "$devMode" == "true" ]]; then
+    if $devMode; then
       args+=('--sourcemap=linked')
     fi
   ;;
@@ -108,12 +126,8 @@ esac
 # FIXME: what about down-leveling?
 # esbuild target: ['chrome109', 'firefox115', 'safari15.6', 'ios15.8'],
 
-bun \
-  --prefer-offline \
-  build \
-    --banner="/* ${banner} */" \
-    --outdir="${outdir}" \
-    --define __dev_mode__="${devMode}" \
-    --define __package_name__="'${packageName}'" \
-    --define __package_version__="'${packageVersion}'" \
-    "${args[@]}"
+printf "\033[1;30mBuilding with the following arguments:\n"
+printf "  %s\n" "${args[@]}" | sed 's/^/  /'
+printf "\033[0m\n"
+
+bun --prefer-offline build "${args[@]}"

--- a/pkg/nanolib/nano-build/cli.sh
+++ b/pkg/nanolib/nano-build/cli.sh
@@ -127,7 +127,7 @@ esac
 # esbuild target: ['chrome109', 'firefox115', 'safari15.6', 'ios15.8'],
 
 printf "\033[1;30mBuilding with the following arguments:\n"
-printf "  %s\n" "${args[@]}" | sed 's/^/  /'
+printf "  %s\n" "${args[@]}"
 printf "\033[0m\n"
 
 bun --prefer-offline build "${args[@]}"

--- a/pkg/nanolib/nano-build/cli.sh
+++ b/pkg/nanolib/nano-build/cli.sh
@@ -49,6 +49,7 @@ for arg in "$@"; do
       echoColor 7 "Flags:\n"
       echoColor 6 "  --preset=module|web|node-service|bun-service  Select a build preset\n"
       echoColor 6 "  --outdir=DIR                                  Specify output directory (default: dist)\n"
+      echoColor 6 "  --debug                                       Enable debug mode (no minification, always sourcemaps)\n"
       echoColor 6 "  --help, -h                                    Show this help message\n"
       echoColor 7 "\nPreset values:\n"
       echoColor 6 "  module       Library/module output (esm, external packages)\n"


### PR DESCRIPTION
## Description

Enhance the development experience by introducing a `--debug` option that allows for streamlined debugging and skips minification. Correct the argument formatting for build presets in the CLI script to ensure proper functionality.

