### PR TITLE
Refactor TypeScript configuration and clean up settings

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -24,6 +24,7 @@
     "scripts",
     "files",
     "publishConfig",
+    "prettier",
     "keywords"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,17 +27,9 @@
     // "**/*.tsbuildinfo": true
   },
   "git.autoStash": true,
-  "git.branchProtection": [
-    "main",
-    "next"
-  ],
-  "githubPullRequests.ignoredPullRequestBranches": [
-    "main",
-    "next"
-  ],
-  "markdownlint.ignore": [
-    "**/CHANGELOG.md"
-  ],
+  "git.branchProtection": ["main", "next"],
+  "githubPullRequests.ignoredPullRequestBranches": ["main", "next"],
+  "markdownlint.ignore": ["**/CHANGELOG.md"],
   "prettier.useEditorConfig": true,
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "cSpell.words": [
@@ -61,14 +53,10 @@
     "typeof",
     "cyrb53"
   ],
-  "github-actions.workflows.pinned.workflows": [
-    ".github/workflows/publish-npm.yml"
-  ],
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "github-actions.workflows.pinned.workflows": [".github/workflows/publish-npm.yml"],
   "[yaml]": {
     "editor.defaultFormatter": "redhat.vscode-yaml"
-  },
-  "[javascript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
   },
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "material-icon-theme.folders.associations": {

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "alwatr-devkit-monorepo",
       "devDependencies": {
+        "@alwatr/standard": "workspace:*",
         "@lerna-lite/cli": "^5.0.0",
         "@lerna-lite/publish": "^5.0.0",
         "@lerna-lite/run": "^5.0.0",
@@ -49,7 +50,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "typescript": "^6.0.2",
       },
     },
@@ -58,7 +59,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "typescript": "^6.0.2",
       },
     },
@@ -71,7 +72,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -84,7 +85,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -97,7 +98,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -108,7 +109,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -118,7 +119,7 @@
       "version": "9.2.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -133,7 +134,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -143,7 +144,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -157,7 +158,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -168,7 +169,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -181,7 +182,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -192,7 +193,7 @@
       "version": "9.2.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -211,7 +212,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -221,7 +222,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -231,7 +232,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -244,7 +245,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -255,7 +256,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -265,7 +266,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -275,7 +276,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -285,7 +286,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -295,7 +296,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -305,7 +306,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -318,7 +319,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -332,7 +333,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -353,7 +354,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -367,7 +368,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -377,17 +378,10 @@
       "version": "9.2.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
-      },
-    },
-    "pkg/nanolib/prettier-config": {
-      "name": "@alwatr/prettier-config",
-      "version": "9.2.0",
-      "devDependencies": {
-        "prettier": "^3.8.1",
       },
     },
     "pkg/nanolib/random": {
@@ -398,7 +392,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -411,7 +405,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -421,7 +415,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -434,7 +428,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -448,15 +442,11 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@happy-dom/global-registrator": "^20.8.9",
         "typescript": "^6.0.2",
       },
-    },
-    "pkg/nanolib/tsconfig-base": {
-      "name": "@alwatr/tsconfig-base",
-      "version": "9.1.1",
     },
     "pkg/nanolib/type-helper": {
       "name": "@alwatr/type-helper",
@@ -470,7 +460,7 @@
       "version": "9.1.1",
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -485,7 +475,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -499,7 +489,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -513,7 +503,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -531,7 +521,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -552,7 +542,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -568,7 +558,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -590,7 +580,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -604,7 +594,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -623,7 +613,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "@types/node": "^24.12.2",
         "typescript": "^6.0.2",
@@ -640,7 +630,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "typescript": "^6.0.2",
       },
     },
@@ -653,7 +643,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -670,7 +660,7 @@
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
-        "@alwatr/tsconfig-base": "workspace:*",
+        "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
         "typescript": "^6.0.2",
       },
@@ -764,8 +754,6 @@
 
     "@alwatr/pre-handlers": ["@alwatr/pre-handlers@workspace:pkg/nanotron-old/pre-handlers"],
 
-    "@alwatr/prettier-config": ["@alwatr/prettier-config@workspace:pkg/nanolib/prettier-config"],
-
     "@alwatr/random": ["@alwatr/random@workspace:pkg/nanolib/random"],
 
     "@alwatr/render-state": ["@alwatr/render-state@workspace:pkg/nanolib/render-state"],
@@ -779,8 +767,6 @@
     "@alwatr/standard": ["@alwatr/standard@workspace:pkg/standard"],
 
     "@alwatr/synapse": ["@alwatr/synapse@workspace:pkg/nanolib/synapse"],
-
-    "@alwatr/tsconfig-base": ["@alwatr/tsconfig-base@workspace:pkg/nanolib/tsconfig-base"],
 
     "@alwatr/type-helper": ["@alwatr/type-helper@workspace:pkg/nanolib/type-helper"],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "conventional-commits-filter": "^5.0.0",
     "typescript": "^6.0.2"
   },
+  "prettier": "./pkg/standard/prettier.config.js",
   "scripts": {
     "b": "bun run build",
     "build": "lerna run build",

--- a/pkg/core/package.json
+++ b/pkg/core/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "typescript": "^6.0.2"
   },
   "scripts": {

--- a/pkg/core/tsconfig.json
+++ b/pkg/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/devtools/package.json
+++ b/pkg/devtools/package.json
@@ -27,7 +27,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "typescript": "^6.0.2"
   },
   "scripts": {

--- a/pkg/devtools/tsconfig.json
+++ b/pkg/devtools/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/fsm/package.json
+++ b/pkg/fsm/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/fsm/tsconfig.json
+++ b/pkg/fsm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/async-queue/package.json
+++ b/pkg/nanolib/async-queue/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/async-queue/tsconfig.json
+++ b/pkg/nanolib/async-queue/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/crypto/package.json
+++ b/pkg/nanolib/crypto/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/crypto/tsconfig.json
+++ b/pkg/nanolib/crypto/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/cyrb53/package.json
+++ b/pkg/nanolib/cyrb53/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/cyrb53/tsconfig.json
+++ b/pkg/nanolib/cyrb53/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/debounce/package.json
+++ b/pkg/nanolib/debounce/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/debounce/tsconfig.json
+++ b/pkg/nanolib/debounce/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/dedupe/package.json
+++ b/pkg/nanolib/dedupe/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/dedupe/tsconfig.json
+++ b/pkg/nanolib/dedupe/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/deep-clone/package.json
+++ b/pkg/nanolib/deep-clone/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/deep-clone/tsconfig.json
+++ b/pkg/nanolib/deep-clone/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/delay/package.json
+++ b/pkg/nanolib/delay/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/delay/tsconfig.json
+++ b/pkg/nanolib/delay/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/djb2-hash/package.json
+++ b/pkg/nanolib/djb2-hash/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/djb2-hash/tsconfig.json
+++ b/pkg/nanolib/djb2-hash/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/env/package.json
+++ b/pkg/nanolib/env/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/env/tsconfig.json
+++ b/pkg/nanolib/env/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/exit-hook/package.json
+++ b/pkg/nanolib/exit-hook/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/exit-hook/tsconfig.json
+++ b/pkg/nanolib/exit-hook/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/fetch/package.json
+++ b/pkg/nanolib/fetch/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/fetch/tsconfig.json
+++ b/pkg/nanolib/fetch/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/flat-string/package.json
+++ b/pkg/nanolib/flat-string/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/flat-string/tsconfig.json
+++ b/pkg/nanolib/flat-string/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/flatomise/package.json
+++ b/pkg/nanolib/flatomise/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/flatomise/tsconfig.json
+++ b/pkg/nanolib/flatomise/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/global-this/package.json
+++ b/pkg/nanolib/global-this/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/global-this/tsconfig.json
+++ b/pkg/nanolib/global-this/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/has-own/package.json
+++ b/pkg/nanolib/has-own/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/has-own/tsconfig.json
+++ b/pkg/nanolib/has-own/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/hash-string/package.json
+++ b/pkg/nanolib/hash-string/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/hash-string/tsconfig.json
+++ b/pkg/nanolib/hash-string/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/http-primer/package.json
+++ b/pkg/nanolib/http-primer/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/http-primer/tsconfig.json
+++ b/pkg/nanolib/http-primer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/iranian-national-code-validator/package.json
+++ b/pkg/nanolib/iranian-national-code-validator/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/iranian-national-code-validator/tsconfig.json
+++ b/pkg/nanolib/iranian-national-code-validator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/is-number/package.json
+++ b/pkg/nanolib/is-number/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/is-number/tsconfig.json
+++ b/pkg/nanolib/is-number/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/json2csv/package.json
+++ b/pkg/nanolib/json2csv/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/json2csv/tsconfig.json
+++ b/pkg/nanolib/json2csv/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/local-storage/package.json
+++ b/pkg/nanolib/local-storage/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/local-storage/tsconfig.json
+++ b/pkg/nanolib/local-storage/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/logger/package.json
+++ b/pkg/nanolib/logger/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/logger/tsconfig.json
+++ b/pkg/nanolib/logger/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/node-fs/package.json
+++ b/pkg/nanolib/node-fs/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/node-fs/tsconfig.json
+++ b/pkg/nanolib/node-fs/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/parse-duration/package.json
+++ b/pkg/nanolib/parse-duration/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/parse-duration/tsconfig.json
+++ b/pkg/nanolib/parse-duration/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/platform-info/package.json
+++ b/pkg/nanolib/platform-info/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/platform-info/tsconfig.json
+++ b/pkg/nanolib/platform-info/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/random/package.json
+++ b/pkg/nanolib/random/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/random/tsconfig.json
+++ b/pkg/nanolib/random/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/render-state/package.json
+++ b/pkg/nanolib/render-state/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/render-state/tsconfig.json
+++ b/pkg/nanolib/render-state/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/resolve-url/package.json
+++ b/pkg/nanolib/resolve-url/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/resolve-url/tsconfig.json
+++ b/pkg/nanolib/resolve-url/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/session-storage/package.json
+++ b/pkg/nanolib/session-storage/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/session-storage/tsconfig.json
+++ b/pkg/nanolib/session-storage/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/synapse/package.json
+++ b/pkg/nanolib/synapse/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@happy-dom/global-registrator": "^20.8.9",
     "typescript": "^6.0.2"

--- a/pkg/nanolib/synapse/tsconfig.json
+++ b/pkg/nanolib/synapse/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanolib/unicode-digits/package.json
+++ b/pkg/nanolib/unicode-digits/package.json
@@ -22,7 +22,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/nanolib/unicode-digits/tsconfig.json
+++ b/pkg/nanolib/unicode-digits/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanotron-old/api-server/package.json
+++ b/pkg/nanotron-old/api-server/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanotron-old/api-server/tsconfig.json
+++ b/pkg/nanotron-old/api-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanotron-old/pre-handlers/package.json
+++ b/pkg/nanotron-old/pre-handlers/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanotron-old/pre-handlers/tsconfig.json
+++ b/pkg/nanotron-old/pre-handlers/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nanotron/package.json
+++ b/pkg/nanotron/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nanotron/tsconfig.json
+++ b/pkg/nanotron/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nitrobase-old/engine/package.json
+++ b/pkg/nitrobase-old/engine/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nitrobase-old/engine/tsconfig.json
+++ b/pkg/nitrobase-old/engine/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nitrobase-old/helper/package.json
+++ b/pkg/nitrobase-old/helper/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nitrobase-old/helper/tsconfig.json
+++ b/pkg/nitrobase-old/helper/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nitrobase-old/reference/package.json
+++ b/pkg/nitrobase-old/reference/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nitrobase-old/reference/tsconfig.json
+++ b/pkg/nitrobase-old/reference/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nitrobase-old/types/package.json
+++ b/pkg/nitrobase-old/types/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nitrobase-old/types/tsconfig.json
+++ b/pkg/nitrobase-old/types/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nitrobase-old/user-management/package.json
+++ b/pkg/nitrobase-old/user-management/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nitrobase-old/user-management/tsconfig.json
+++ b/pkg/nitrobase-old/user-management/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/nitrobase/package.json
+++ b/pkg/nitrobase/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2"

--- a/pkg/nitrobase/tsconfig.json
+++ b/pkg/nitrobase/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/node/package.json
+++ b/pkg/node/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "typescript": "^6.0.2"
   },
   "scripts": {

--- a/pkg/node/tsconfig.json
+++ b/pkg/node/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",

--- a/pkg/playground/package.json
+++ b/pkg/playground/package.json
@@ -27,10 +27,11 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },
+  "prettier": "@alwatr/standard/prettier",
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",

--- a/pkg/playground/tsconfig.json
+++ b/pkg/playground/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "noEmit": true,

--- a/pkg/signal/package.json
+++ b/pkg/signal/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",
-    "@alwatr/tsconfig-base": "workspace:*",
+    "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
     "typescript": "^6.0.2"
   },

--- a/pkg/signal/tsconfig.json
+++ b/pkg/signal/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@alwatr/tsconfig-base",
+  "extends": "@alwatr/standard/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",


### PR DESCRIPTION
## Description

Clean up `settings.json` by removing unnecessary comments and reformatting. Update TypeScript configuration to extend from `@alwatr/standard/tsconfig` and replace `@alwatr/tsconfig-base` with `@alwatr/standard`. Add Prettier configuration to ensure consistent code formatting.