### PR TITLE
feat(directive): add @on event decorator for DOM event handling

### DIFF
--- a/.kiro/specs/event-decorator/.config.kiro
+++ b/.kiro/specs/event-decorator/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "57975460-3724-4113-9e78-71f2f0eacfcf", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/event-decorator/design.md
+++ b/.kiro/specs/event-decorator/design.md
@@ -1,0 +1,158 @@
+# Design Document
+
+## Feature: `@on` Event Decorator
+
+---
+
+## Overview
+
+Add an `@on(eventType, selector?, options?)` method decorator to `pkg/nanolib/directive/src/util-decorators.ts`.
+
+When applied to a method in a `DirectiveBase` subclass, the decorator:
+
+1. Registers a DOM event listener on `this.element_` (or a child matching `selector`) after the directive initializes.
+2. Automatically removes the listener via `addDestroyHook` when the directive is destroyed.
+
+The implementation follows the KISS principle and mirrors the existing `@query`, `@queryAll`, and `@attribute` decorators in the same file.
+
+---
+
+## Architecture
+
+The decorator uses the TypeScript stage-3 `ClassMethodDecoratorContext` API — the same pattern already used in the codebase. It hooks into the directive lifecycle via `context.addInitializer`, which runs after the class instance is constructed (i.e., after `this.element_` is available).
+
+```
+@on('click') applied to method
+        │
+        ▼
+context.addInitializer runs on instance creation
+        │
+        ├─ resolve target element (this.element_ or querySelector result)
+        ├─ bind method to `this`
+        ├─ call targetElement.addEventListener(eventType, boundMethod, options)
+        └─ call this.addDestroyHook(() => targetElement.removeEventListener(...))
+```
+
+No changes to `DirectiveBase` are required. The decorator is entirely self-contained in `util-decorators.ts`.
+
+---
+
+## Components and Interfaces
+
+### `on` function signature
+
+```ts
+export function on(
+  eventType: keyof HTMLElementEventMap | string,
+  selector?: string,
+  options?: AddEventListenerOptions | boolean,
+): (
+  target: (this: DirectiveBase, event: Event) => void,
+  context: ClassMethodDecoratorContext<DirectiveBase, (event: Event) => void>,
+) => void;
+```
+
+### Usage examples
+
+```ts
+@directive('[my-directive]')
+class MyDirective extends DirectiveBase {
+  protected init_(): void {}
+
+  // Listen on this.element_
+  @on('click')
+  protected onClick_(event: Event): void {
+    console.log('clicked', event);
+  }
+
+  // Listen on a child element
+  @on('input', '.search-input')
+  protected onInput_(event: Event): void {
+    console.log('input', (event.target as HTMLInputElement).value);
+  }
+
+  // With options
+  @on('scroll', undefined, {passive: true})
+  protected onScroll_(event: Event): void {
+    /* ... */
+  }
+}
+```
+
+---
+
+## Data Models
+
+No new data models are introduced. The decorator relies entirely on existing browser APIs (`addEventListener`, `removeEventListener`, `querySelector`) and the existing `DirectiveBase` lifecycle (`addDestroyHook`).
+
+The only internal state is the bound method reference, which is captured in the closure created by `context.addInitializer` and reused for both `addEventListener` and `removeEventListener`.
+
+---
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Listener is invoked with the Event object
+
+_For any_ event type string and any `DirectiveBase` subclass with an `@on(eventType)`-decorated method, dispatching that event on the target element SHALL invoke the decorated method exactly once with the dispatched `Event` object as its argument.
+
+**Validates: Requirements 2.1, 2.2**
+
+### Property 2: `this` binding is the directive instance
+
+_For any_ `DirectiveBase` subclass instance with an `@on`-decorated method, when the event fires, the value of `this` inside the decorated method SHALL be the directive instance.
+
+**Validates: Requirements 2.3**
+
+### Property 3: All `@on` listeners are removed after destroy
+
+_For any_ `DirectiveBase` subclass with one or more `@on`-decorated methods, after `destroy()` is called, dispatching any of the registered event types on the target elements SHALL NOT invoke any of the decorated methods.
+
+**Validates: Requirements 3.1, 3.2, 4.3**
+
+---
+
+## Error Handling
+
+| Scenario                                               | Behavior                                                                                      |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `@on` applied to a non-method (accessor, field)        | Throw `Error` with descriptive message at decoration time                                     |
+| `selector` provided but `querySelector` returns `null` | Log a warning via `this.logger_`, skip `addEventListener` silently                            |
+| `destroy()` called before `init_()` completes          | No-op — `addDestroyHook` list is empty or the hook removes a never-registered listener (safe) |
+
+---
+
+## Testing Strategy
+
+### Unit tests (example-based)
+
+- `@on` is exported as a function from `util-decorators`.
+- Applying `@on` to a non-method throws at decoration time.
+- Two methods decorated with `@on('click')` both fire when click is dispatched.
+- Providing a selector that matches nothing logs a warning and does not throw.
+
+### Property-based tests
+
+Using **fast-check** (already available in the JS ecosystem; consistent with Bun test runner).
+Each property test runs a minimum of **100 iterations**.
+
+Tag format: `Feature: event-decorator, Property {N}: {property_text}`
+
+**Property 1 test** — `Feature: event-decorator, Property 1: listener is invoked with the Event object`
+
+- Generate: random event type strings (from a fixed set of valid DOM event names + arbitrary strings)
+- Setup: create a `DirectiveBase` subclass with `@on(eventType)`, attach to a DOM element
+- Assert: dispatching the event calls the method exactly once with the correct `Event` instance
+
+**Property 2 test** — `Feature: event-decorator, Property 2: this binding is the directive instance`
+
+- Generate: random event type strings
+- Setup: same as Property 1, capture `this` inside the decorated method
+- Assert: captured `this === directiveInstance`
+
+**Property 3 test** — `Feature: event-decorator, Property 3: all @on listeners are removed after destroy`
+
+- Generate: random sets of 1–5 event types
+- Setup: create a directive with `@on` on multiple methods, call `destroy()`, dispatch all events
+- Assert: none of the decorated methods are called after destroy

--- a/.kiro/specs/event-decorator/requirements.md
+++ b/.kiro/specs/event-decorator/requirements.md
@@ -1,0 +1,84 @@
+# Requirements Document
+
+## Introduction
+
+Add an `@on` method decorator to the `@alwatr/directive` package (`pkg/nanolib/directive/src/util-decorators.ts`).
+When applied to a method in a `DirectiveBase` subclass, the decorator automatically registers a DOM event listener on `this.element_` (or on a matching child element when a CSS selector is provided) for the specified event type, and automatically removes it when the directive is destroyed — all without any manual `addEventListener` / `removeEventListener` calls.
+
+The decorator signature is `@on(eventType, selector?)`. When `selector` is omitted the listener is registered directly on `this.element_`. When `selector` is provided, the listener is registered on the first child element matching `this.element_.querySelector(selector)`. There is no `root` parameter — the query scope is always limited to within the directive's own `this.element_`.
+
+The name `@on` is chosen following the KISS principle: it is the shortest, most idiomatic name for event binding in the JavaScript ecosystem (mirrors `element.onclick`, `on('click', ...)` patterns), and is consistent with the existing terse decorator names (`@query`, `@queryAll`, `@attribute`).
+
+## Glossary
+
+- **Decorator**: A TypeScript stage-3 class decorator applied with `@` syntax.
+- **DirectiveBase**: The abstract base class (`pkg/nanolib/directive/src/directive-class.ts`) that all directives extend. Exposes `element_: HTMLElement` and `addDestroyHook(fn)`.
+- **`@on` decorator**: The new method decorator defined in `util-decorators.ts` that wires a class method to a DOM event listener. Accepts an optional `selector` parameter to target a child element.
+- **Event type**: A string identifying a DOM event (e.g. `'click'`, `'input'`, `'change'`).
+- **Selector**: An optional CSS selector string (`string | undefined`) passed as the second argument to `@on`. When provided, the listener is registered on the first child element found via `this.element_.querySelector(selector)` rather than on `this.element_` itself. The query is always scoped within the directive's own `this.element_` — there is no `root` parameter.
+- **Target element**: The DOM element on which the event listener is actually registered — either `this.element_` (no selector) or the result of `this.element_.querySelector(selector)`.
+- **Listener**: The bound class method registered via `addEventListener`.
+- **Destroy hook**: A cleanup callback registered via `DirectiveBase.addDestroyHook` that runs when the directive is destroyed.
+
+---
+
+## Requirements
+
+### Requirement 1: Decorator Definition
+
+**User Story:** As a directive author, I want an `@on(eventType)` method decorator, so that I can declaratively bind a class method to a DOM event without writing boilerplate `addEventListener` calls.
+
+#### Acceptance Criteria
+
+1. THE `util-decorators` module SHALL export a function named `on` that accepts an `eventType` string parameter and returns a method decorator.
+2. WHEN `@on` is applied to a non-method class member, THE `on` decorator SHALL throw an `Error` with a descriptive message.
+3. THE `on` decorator SHALL accept an optional `options` parameter of type `AddEventListenerOptions` to allow passive, capture, and once configurations.
+4. THE `on` decorator SHALL accept an optional `selector` parameter (typed as `string | undefined`) as its second argument. WHEN `selector` is provided, the event listener is registered on the first matching child element found via `this.element_.querySelector(selector)` instead of `this.element_` itself. There is no `root` parameter — the query scope is always limited to within the directive's own `this.element_`.
+
+---
+
+### Requirement 2: Event Listener Registration
+
+**User Story:** As a directive author, I want the decorated method to be automatically called when the specified event fires on `this.element_`, so that I don't need to manually call `addEventListener` in `init_`.
+
+#### Acceptance Criteria
+
+1. WHEN a `DirectiveBase` subclass instance is initialized and no `selector` is provided, THE `on` decorator SHALL call `this.element_.addEventListener(eventType, boundMethod, options)` to register the listener directly on `this.element_`. WHEN a `selector` is provided, THE `on` decorator SHALL call `this.element_.querySelector(selector)` to find the target element and register the listener on that element instead.
+2. WHEN the specified DOM event fires on the target element, THE `on` decorator SHALL invoke the decorated method with the `Event` object as its argument.
+3. THE `on` decorator SHALL bind the decorated method to the directive instance (`this`) so that `this` inside the method refers to the directive.
+4. WHEN a `selector` is provided but `this.element_.querySelector(selector)` returns `null`, THE `on` decorator SHALL log a warning and skip registration without throwing an error.
+
+---
+
+### Requirement 3: Lifecycle — Automatic Cleanup
+
+**User Story:** As a directive author, I want the event listener to be removed automatically when the directive is destroyed, so that there are no memory leaks or stale listeners.
+
+#### Acceptance Criteria
+
+1. WHEN the directive's `destroy()` method is called, THE `on` decorator SHALL remove the previously registered event listener via `targetElement.removeEventListener(eventType, boundMethod, options)`, where `targetElement` is the same element the listener was registered on (either `this.element_` when no selector was provided, or the child element returned by `this.element_.querySelector(selector)`).
+2. THE `on` decorator SHALL register the removal callback using `this.addDestroyHook(...)` so cleanup integrates with the existing lifecycle.
+
+---
+
+### Requirement 4: Multiple `@on` Decorators on the Same Class
+
+**User Story:** As a directive author, I want to apply `@on` to multiple methods in the same class (including the same event type on different methods), so that I can handle different events or multiple handlers cleanly.
+
+#### Acceptance Criteria
+
+1. THE `DirectiveBase` subclass SHALL support any number of `@on`-decorated methods, each registering its own independent listener.
+2. WHEN two methods are decorated with `@on('click')`, THE `on` decorator SHALL register both methods as separate listeners on `this.element_`.
+3. WHEN the directive is destroyed, THE `on` decorator SHALL remove all listeners registered by all `@on`-decorated methods on that instance.
+
+---
+
+### Requirement 5: TypeScript Typing
+
+**User Story:** As a directive author, I want full TypeScript type safety on the decorator, so that incorrect usage is caught at compile time.
+
+#### Acceptance Criteria
+
+1. THE `on` decorator SHALL be typed to accept only `ClassMethodDecoratorContext` so that applying it to accessors or fields produces a TypeScript compile error.
+2. THE `on` decorator's `eventType` parameter SHALL be typed as `keyof HTMLElementEventMap | string` to provide autocomplete for standard events while allowing custom event names.
+3. THE `on` decorator's `options` parameter SHALL be typed as `AddEventListenerOptions | boolean | undefined`.

--- a/.kiro/specs/event-decorator/tasks.md
+++ b/.kiro/specs/event-decorator/tasks.md
@@ -1,0 +1,59 @@
+# Implementation Plan: `@on` Event Decorator
+
+## Overview
+
+Implement the `@on(eventType, selector?, options?)` method decorator in `pkg/nanolib/directive/src/util-decorators.ts`, following the same patterns as the existing `@query`, `@queryAll`, and `@attribute` decorators. Add property-based tests using fast-check alongside the existing example-based tests in `util-decorators.test.ts`.
+
+## Tasks
+
+- [x] 1. Implement the `on` decorator in `util-decorators.ts`
+  - Add the exported `on` function after the existing `attribute` decorator
+  - Signature: `on(eventType: keyof HTMLElementEventMap | string, selector?: string, options?: AddEventListenerOptions | boolean)`
+  - Return a decorator typed to `ClassMethodDecoratorContext<DirectiveBase, (event: Event) => void>`
+  - Throw `Error` with descriptive message if `context.kind !== 'method'`
+  - Inside `context.addInitializer`:
+    - Resolve target element: `selector ? this.element_.querySelector(selector) : this.element_`
+    - If selector provided and result is `null`, call `this.logger_.warn(...)` and return early
+    - Bind the decorated method to `this`: `const boundMethod = value.bind(this)`
+    - Call `targetElement.addEventListener(eventType, boundMethod, options)`
+    - Call `this.addDestroyHook(() => targetElement.removeEventListener(eventType, boundMethod, options))`
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.3, 2.4, 3.1, 3.2_
+
+- [x] 2. Write example-based unit tests for `@on` in `util-decorators.test.ts`
+  - [x] 2.1 Add unit tests for basic `@on` behavior
+    - Test: `@on` is exported from `util-decorators`
+    - Test: applying `@on` to a non-method throws at decoration time
+    - Test: decorated method is called when the event fires on `this.element_`
+    - Test: two methods decorated with `@on('click')` both fire on a single click
+    - Test: `this` inside the decorated method is the directive instance
+    - Test: listener is removed after `destroy()` is called
+    - Test: selector that matches a child element registers listener on that child
+    - Test: selector that matches nothing logs a warning and does not throw
+    - _Requirements: 1.1, 1.2, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 4.1, 4.2, 4.3_
+
+  - [ ] 2.2 Write property test for Property 1: listener is invoked with the Event object
+    - **Property 1: Listener is invoked with the Event object**
+    - **Validates: Requirements 2.1, 2.2**
+    - Use `fc.constantFrom(...domEventNames)` to generate random event type strings
+    - For each generated event type: create a directive instance, dispatch the event, assert the method was called exactly once with the correct `Event` instance
+    - Tag: `Feature: event-decorator, Property 1: listener is invoked with the Event object`
+    - Run minimum 100 iterations
+
+  - [ ]\* 2.3 Write property test for Property 2: `this` binding is the directive instance
+    - **Property 2: `this` binding is the directive instance**
+    - **Validates: Requirements 2.3**
+    - Use `fc.constantFrom(...domEventNames)` to generate random event type strings
+    - For each generated event type: capture `this` inside the decorated method when the event fires, assert `capturedThis === directiveInstance`
+    - Tag: `Feature: event-decorator, Property 2: this binding is the directive instance`
+    - Run minimum 100 iterations
+
+  - [ ]\* 2.4 Write property test for Property 3: all `@on` listeners are removed after destroy
+    - **Property 3: All `@on` listeners are removed after destroy**
+    - **Validates: Requirements 3.1, 3.2, 4.3**
+    - Use `fc.array(fc.constantFrom(...domEventNames), {minLength: 1, maxLength: 5})` to generate random sets of event types
+    - For each generated set: create a directive with `@on` on multiple methods, call `destroy()`, dispatch all events, assert none of the decorated methods were called
+    - Tag: `Feature: event-decorator, Property 3: all @on listeners are removed after destroy`
+    - Run minimum 100 iterations
+
+- [x] 3. Checkpoint — Ensure all tests pass
+  - Run `bun test` in `pkg/nanolib/directive` and confirm all tests pass. Ask the user if any questions arise.

--- a/pkg/nanolib/directive/src/util-decorators.test.ts
+++ b/pkg/nanolib/directive/src/util-decorators.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'bun:test';
 import {GlobalRegistrator} from '@happy-dom/global-registrator';
 import {DirectiveBase} from './directive-class.js';
-import {attribute, query, queryAll} from './util-decorators.js';
+import {attribute, on, query, queryAll} from './util-decorators.js';
 
 GlobalRegistrator.register();
 
@@ -29,7 +29,7 @@ describe('@query', () => {
     const root = document.createElement('div');
     root.innerHTML = '<h1 class="title">Hello</h1>';
 
-    const directive = new TestDirective(root, '[test]');
+    const directive = new TestDirective(root, 'test');
     expect(directive.title?.textContent).toBe('Hello');
   });
 
@@ -37,7 +37,7 @@ describe('@query', () => {
     const root = document.createElement('div');
     root.innerHTML = '<p>no target here</p>';
 
-    const directive = new TestDirective(root, '[test]');
+    const directive = new TestDirective(root, 'test');
     expect(directive.missing).toBeNull();
   });
 
@@ -45,7 +45,7 @@ describe('@query', () => {
     const root = document.createElement('div');
     root.innerHTML = '<h1 class="title">Hello</h1>';
 
-    const directive = new TestDirective(root, '[test]');
+    const directive = new TestDirective(root, 'test');
     const first = directive.title;
     const second = directive.title;
 
@@ -64,7 +64,7 @@ describe('@queryAll', () => {
       </ul>
     `;
 
-    const directive = new TestDirective(root, '[test]');
+    const directive = new TestDirective(root, 'test');
     expect(directive.items.length).toBe(3);
     expect(directive.items[0]?.textContent).toBe('A');
   });
@@ -73,7 +73,7 @@ describe('@queryAll', () => {
     const root = document.createElement('div');
     root.innerHTML = '<div>empty</div>';
 
-    const directive = new TestDirective(root, '[test]');
+    const directive = new TestDirective(root, 'test');
     expect(directive.items.length).toBe(0);
   });
 });
@@ -90,7 +90,7 @@ describe('@attribute', () => {
   it('returns null when attribute is not found', () => {
     const root = document.createElement('div');
 
-    const directive = new TestDirective(root, '[test]');
+    const directive = new TestDirective(root, 'test');
     expect(directive.missingData).toBeNull();
   });
 
@@ -98,12 +98,170 @@ describe('@attribute', () => {
     const root = document.createElement('div');
     root.setAttribute('data-id', '123');
 
-    const directive = new TestDirective(root, '[test]');
+    const directive = new TestDirective(root, 'test');
     const first = directive.dataId;
     root.setAttribute('data-id', '456');
     const second = directive.dataId;
 
     expect(first).toBe('123');
     expect(second).toBe('123');
+  });
+});
+
+describe('@on', () => {
+  it('is exported from util-decorators', () => {
+    expect(typeof on).toBe('function');
+  });
+
+  it('throws at decoration time when applied to a non-method', () => {
+    expect(() => {
+      // Simulate applying @on to an accessor context
+      const decorator = on('click');
+      decorator(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (() => {}) as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {kind: 'accessor', name: 'foo', addInitializer: () => {}} as any,
+      );
+    }).toThrow('@on can only be used on class methods');
+  });
+
+  it('calls the decorated method when the event fires on element_', () => {
+    let callCount = 0;
+
+    class ClickDirective extends DirectiveBase {
+      protected init_(): void {}
+
+      @on('click')
+      onClick(_e: Event): void {
+        callCount++;
+      }
+    }
+
+    const root = document.createElement('div');
+    new ClickDirective(root, 'test');
+
+    root.dispatchEvent(new Event('click'));
+    expect(callCount).toBe(1);
+  });
+
+  it('calls both methods when two @on("click") decorators are applied', () => {
+    let count1 = 0;
+    let count2 = 0;
+
+    class TwoClickDirective extends DirectiveBase {
+      protected init_(): void {}
+
+      @on('click')
+      onClickA(_e: Event): void {
+        count1++;
+      }
+
+      @on('click')
+      onClickB(_e: Event): void {
+        count2++;
+      }
+    }
+
+    const root = document.createElement('div');
+    new TwoClickDirective(root, 'test');
+
+    root.dispatchEvent(new Event('click'));
+    expect(count1).toBe(1);
+    expect(count2).toBe(1);
+  });
+
+  it('binds `this` to the directive instance inside the decorated method', () => {
+    let capturedThis: unknown;
+
+    class ThisDirective extends DirectiveBase {
+      protected init_(): void {}
+
+      @on('click')
+      onClick(_e: Event): void {
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        capturedThis = this;
+      }
+    }
+
+    const root = document.createElement('div');
+    const instance = new ThisDirective(root, 'test');
+
+    root.dispatchEvent(new Event('click'));
+    expect(capturedThis).toBe(instance);
+  });
+
+  it('removes the listener after destroy() is called', async () => {
+    let callCount = 0;
+
+    class DestroyDirective extends DirectiveBase {
+      protected init_(): void {}
+
+      @on('click')
+      onClick(_e: Event): void {
+        callCount++;
+      }
+    }
+
+    const root = document.createElement('div');
+    const instance = new DestroyDirective(root, 'test');
+
+    root.dispatchEvent(new Event('click'));
+    expect(callCount).toBe(1);
+
+    await instance.destroy();
+
+    root.dispatchEvent(new Event('click'));
+    expect(callCount).toBe(1); // no additional calls after destroy
+  });
+
+  it('registers listener on a matching child element when selector is provided', () => {
+    let callCount = 0;
+
+    class ChildDirective extends DirectiveBase {
+      protected init_(): void {}
+
+      @on('click', '.btn')
+      onBtnClick(_e: Event): void {
+        callCount++;
+      }
+    }
+
+    const root = document.createElement('div');
+    root.innerHTML = '<button class="btn">Click me</button>';
+    new ChildDirective(root, 'test');
+
+    const btn = root.querySelector('.btn') as HTMLElement;
+    btn.dispatchEvent(new Event('click'));
+    expect(callCount).toBe(1);
+
+    // Clicking the root itself should NOT trigger the handler
+    root.dispatchEvent(new Event('click'));
+    expect(callCount).toBe(1);
+  });
+
+  it('logs a warning and does not throw when selector matches nothing', () => {
+    let callCount = 0;
+
+    // Should not throw during class definition or instantiation
+    expect(() => {
+      class MissingChildDirective extends DirectiveBase {
+        protected init_(): void {}
+
+        @on('click', '.nonexistent')
+        onMissing(_e: Event): void {
+          callCount++;
+        }
+      }
+
+      const root = document.createElement('div'); // no .nonexistent child
+      new MissingChildDirective(root, 'test');
+
+      // Dispatching the event should not call the handler (listener was never registered)
+      root.dispatchEvent(new Event('click'));
+    }).not.toThrow();
+
+    // Handler was never registered, so it should not have been called
+    expect(callCount).toBe(0);
   });
 });

--- a/pkg/nanolib/directive/src/util-decorators.ts
+++ b/pkg/nanolib/directive/src/util-decorators.ts
@@ -135,3 +135,65 @@ export function attribute(name: string, cache = true, root?: Element) {
     };
   };
 }
+
+/**
+ * A method decorator that registers a DOM event listener on the directive's element (or a matching
+ * child element when a CSS selector is provided). The listener is automatically removed when the
+ * directive is destroyed, preventing memory leaks.
+ *
+ * @param eventType The DOM event type to listen for (e.g. `'click'`, `'input'`).
+ * @param selector Optional CSS selector to target a child element via `this.element_.querySelector(selector)`.
+ *   When omitted, the listener is registered directly on `this.element_`.
+ * @param options Optional `AddEventListenerOptions` or capture boolean passed to `addEventListener`.
+ *
+ * @example
+ * ```ts
+ * @directive('[my-directive]')
+ * class MyDirective extends DirectiveBase {
+ *   protected init_(): void {}
+ *
+ *   // Listen on this.element_
+ *   @on('click')
+ *   protected onClick_(event: Event): void {
+ *     console.log('clicked', event);
+ *   }
+ *
+ *   // Listen on a child element
+ *   @on('input', '.search-input')
+ *   protected onInput_(event: Event): void {
+ *     console.log('input', (event.target as HTMLInputElement).value);
+ *   }
+ *
+ *   // With options
+ *   @on('scroll', undefined, {passive: true})
+ *   protected onScroll_(event: Event): void { }
+ * }
+ * ```
+ */
+export function on(
+  eventType: keyof HTMLElementEventMap | string,
+  selector?: string,
+  options?: AddEventListenerOptions | boolean,
+) {
+  return function (
+    target: (this: DirectiveBase, event: Event) => void,
+    context: ClassMethodDecoratorContext<DirectiveBase, (event: Event) => void>,
+  ): void {
+    if (context.kind !== 'method') {
+      throw new Error('@on can only be used on class methods');
+    }
+
+    context.addInitializer(function (this: DirectiveBase) {
+      const targetElement = selector ? this.element_.querySelector(selector) : this.element_;
+
+      if (selector && targetElement === null) {
+        this.logger_.accident('on', 'selector_not_found', {selector});
+        return;
+      }
+
+      const boundMethod = target.bind(this);
+      (targetElement as HTMLElement).addEventListener(eventType, boundMethod, options);
+      this.addDestroyHook(() => (targetElement as HTMLElement).removeEventListener(eventType, boundMethod, options));
+    });
+  };
+}


### PR DESCRIPTION
## Description

Implement the `@on` method decorator for automatic DOM event listener registration on directive elements. This change enhances event handling capabilities by allowing listeners to be registered on both the directive's element and its child elements, with automatic cleanup upon directive destruction. Comprehensive documentation and tests accompany the implementation to ensure correctness and reliability.

