### PR TITLE
Add `onHidden_()` and update `onVisible_()` lifecycle hooks to improve visibility management in directives

### DIFF
--- a/.kiro/specs/lazy-init-directive/design.md
+++ b/.kiro/specs/lazy-init-directive/design.md
@@ -2,14 +2,20 @@
 
 ## Overview
 
-افزودن دو lifecycle hook اختیاری به کلاس `DirectiveBase` در پکیج `@alwatr/directive`:
+افزودن lifecycle hook های اختیاری به کلاس `DirectiveBase` در پکیج `@alwatr/directive`:
 
 | Hook           | اجرا                                   | تعداد دفعات  |
 | -------------- | -------------------------------------- | ------------ |
+| `init_()`      | بعد از nextMacrotask (optional)        | دقیقاً ۱ بار |
 | `lazyInit_()`  | اولین بار که element وارد viewport شود | دقیقاً ۱ بار |
 | `onVisible_()` | هر بار که element وارد viewport شود    | نامحدود      |
+| `onHidden_()`  | هر بار که element از viewport خارج شود | نامحدود      |
 
-هر دو hook با `IntersectionObserver` پیاده‌سازی می‌شوند. `lazyInit_` در صورت عدم پشتیبانی به `requestIdleCallback` و سپس `setTimeout(100ms)` fallback می‌کند. `onVisible_` در صورت عدم پشتیبانی یک بار در همان لحظه اجرا می‌شود (KISS).
+`init_()` به optional تبدیل شده — directive هایی که فقط از `@on` decorator یا visibility hook استفاده می‌کنند نیازی به تعریف آن ندارند.
+
+`lazyInit_` در صورت عدم پشتیبانی به `requestIdleCallback` و سپس `setTimeout(100ms)` fallback می‌کند. `onVisible_` در صورت عدم پشتیبانی با `setTimeout(100ms)` یک بار اجرا می‌شود. `onHidden_` هیچ fallback ندارد.
+
+`onVisible_` و `onHidden_` یک `IntersectionObserver` مشترک دارند تا از ساخت observer تکراری جلوگیری شود.
 
 ---
 
@@ -51,7 +57,7 @@ sequenceDiagram
             TV->>V: await onVisible_()
             TV->>TV: registered in destroyHookList__
         else fallback
-            TV->>V: await onVisible_() (once, immediately)
+            TV->>V: await onVisible_() (once, after 100ms setTimeout)
         end
     end
 ```
@@ -62,6 +68,12 @@ sequenceDiagram
 
 ```typescript
 /**
+ * Optional lifecycle hook — runs once after next macrotask.
+ * Use for: event listeners, initial DOM setup.
+ */
+protected init_?(): Awaitable<void>;
+
+/**
  * Optional lifecycle hook — runs ONCE when the element first enters the viewport.
  * Falls back to requestIdleCallback or setTimeout(100ms) if IntersectionObserver is unavailable.
  *
@@ -71,11 +83,19 @@ protected lazyInit_?(): Awaitable<void>;
 
 /**
  * Optional lifecycle hook — runs EVERY TIME the element enters the viewport.
- * Falls back to a single immediate execution if IntersectionObserver is unavailable.
+ * Falls back to a single execution via setTimeout(100ms) if IntersectionObserver is unavailable.
  *
  * Use for: impression tracking, restarting animations, refreshing dynamic data.
  */
 protected onVisible_?(): Awaitable<void>;
+
+/**
+ * Optional lifecycle hook — runs EVERY TIME the element leaves the viewport.
+ * No fallback — silently skipped if IntersectionObserver is unavailable.
+ *
+ * Use for: pausing video/audio, cancelling in-progress work, hiding UI.
+ */
+protected onHidden_?(): Awaitable<void>;
 
 /**
  * Handles one-shot lazy execution with environment-aware fallbacks.
@@ -83,9 +103,10 @@ protected onVisible_?(): Awaitable<void>;
 private triggerLazyInit_(): void;
 
 /**
- * Handles persistent visibility tracking with destroy-safe cleanup.
+ * Handles persistent visibility tracking for both onVisible_ and onHidden_.
+ * Creates a single shared IntersectionObserver for both hooks.
  */
-private triggerOnVisible_(): void;
+private triggerVisibilityObserver_(): void;
 ```
 
 ---
@@ -146,7 +167,7 @@ private triggerOnVisible_(): void
 - هر بار که element وارد viewport شود، `onVisible_()` اجرا می‌شود
 - observer در `destroyHookList__` ثبت می‌شود تا هنگام `destroy()` قطع شود
 - خطاهای داخل `onVisible_()` با `logger_.error` لاگ می‌شوند و exception بالا نمی‌رود
-- اگر `IntersectionObserver` موجود نباشد، یک بار بلافاصله اجرا می‌شود
+- اگر `IntersectionObserver` موجود نباشد، یک بار با `setTimeout(100ms)` اجرا می‌شود
 
 ---
 
@@ -195,12 +216,12 @@ constructor(element: HTMLElement, attributeName: string) {
 
   (async () => {
     await delay.nextMacrotask();
-    await this.init_();
+    await this.init_?.();
     if (typeof this.lazyInit_ === 'function') {
       this.triggerLazyInit_();
     }
-    if (typeof this.onVisible_ === 'function') {
-      this.triggerOnVisible_();
+    if (typeof this.onVisible_ === 'function' || typeof this.onHidden_ === 'function') {
+      this.triggerVisibilityObserver_();
     }
   })();
 }
@@ -236,30 +257,35 @@ private triggerLazyInit_(): void {
 }
 ```
 
-### `triggerOnVisible_` Algorithm
+### `triggerVisibilityObserver_` Algorithm
 
 ```typescript
-private triggerOnVisible_(): void {
-  const execute = async () => {
-    try {
-      await this.onVisible_!();
-    } catch (err) {
-      this.logger_.error('triggerOnVisible_', 'error_in_on_visible', err);
-    }
-  };
-
+private triggerVisibilityObserver_(): void {
   if (typeof IntersectionObserver !== 'undefined') {
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) {
-        void execute();
+    const observer = new IntersectionObserver(async (entries) => {
+      if (this.isDestroyed()) return;
+      const entry = entries[0];
+      if (entry.isIntersecting) {
+        if (this.onVisible_) {
+          try { await this.onVisible_(); }
+          catch (err) { this.logger_.error('triggerVisibilityObserver_', 'error_in_on_visible', err); }
+        }
+      } else {
+        if (this.onHidden_) {
+          try { await this.onHidden_(); }
+          catch (err) { this.logger_.error('triggerVisibilityObserver_', 'error_in_on_hidden', err); }
+        }
       }
     });
     observer.observe(this.element_);
-    // Always register cleanup — observer is persistent
+    // Single cleanup entry for both hooks
     this.addDestroyHook(() => observer.disconnect());
-  } else {
-    // Fallback: run once immediately (KISS — no scroll listener complexity)
-    void execute();
+  } else if (this.onVisible_) {
+    // Fallback: run onVisible_ once after 100ms. onHidden_ has no meaningful fallback.
+    setTimeout(async () => {
+      try { await this.onVisible_!(); }
+      catch (err) { this.logger_.error('triggerVisibilityObserver_', 'error_in_on_visible', err); }
+    }, 100);
   }
 }
 ```
@@ -268,13 +294,14 @@ private triggerOnVisible_(): void {
 
 ## DX Comparison
 
-|                     | `init_()`                   | `lazyInit_()`               | `onVisible_()`                         |
-| ------------------- | --------------------------- | --------------------------- | -------------------------------------- |
-| **زمان اجرا**       | بعد از nextMacrotask        | اولین بار در viewport       | هر بار در viewport                     |
-| **تعداد اجرا**      | ۱ بار                       | ۱ بار                       | نامحدود                                |
-| **مناسب برای**      | event listener، setup اولیه | lazy load تصویر، fetch داده | impression tracking، animation restart |
-| **cleanup خودکار**  | —                           | ✅                          | ✅                                     |
-| **error isolation** | —                           | ✅                          | ✅                                     |
+|                     | `init_()?`                  | `lazyInit_()?`                   | `onVisible_()?`                        | `onHidden_()?`           |
+| ------------------- | --------------------------- | -------------------------------- | -------------------------------------- | ------------------------ |
+| **زمان اجرا**       | بعد از nextMacrotask        | اولین بار در viewport            | هر بار در viewport                     | هر بار خروج از viewport  |
+| **تعداد اجرا**      | ۱ بار                       | ۱ بار                            | نامحدود                                | نامحدود                  |
+| **مناسب برای**      | event listener، setup اولیه | lazy load تصویر، fetch داده      | impression tracking، animation restart | pause video، cancel work |
+| **cleanup خودکار**  | —                           | ✅                               | ✅ (shared observer)                   | ✅ (shared observer)     |
+| **error isolation** | —                           | ✅                               | ✅                                     | ✅                       |
+| **fallback**        | —                           | requestIdleCallback → setTimeout | setTimeout(100ms)                      | ندارد                    |
 
 ---
 
@@ -286,19 +313,24 @@ import {directive, DirectiveBase} from '@alwatr/directive';
 @directive('product-card-tracker')
 export class ProductCardTrackerDirective extends DirectiveBase {
   // ۱. اجرای فوری — event listener وصل می‌کنیم
-  protected init_(): void {
+  protected override init_(): void {
     this.element_.addEventListener('click', this.handleClick_);
   }
 
   // ۲. اجرای یک‌بار با تأخیر — تصویر سنگین رو lazy load می‌کنیم
-  protected lazyInit_(): void {
+  protected override lazyInit_(): void {
     const img = this.element_.querySelector('img')!;
     img.src = img.dataset['src']!;
   }
 
   // ۳. اجرای تکرارشونده — هر بار که کارت دیده شد impression می‌فرستیم
-  protected onVisible_(): void {
+  protected override onVisible_(): void {
     AnalyticsService.sendImpression(this.attributeValue);
+  }
+
+  // ۴. هر بار که کارت از دید خارج شد
+  protected override onHidden_(): void {
+    AnalyticsService.sendHidden(this.attributeValue);
   }
 
   private handleClick_ = () => {
@@ -311,11 +343,11 @@ export class ProductCardTrackerDirective extends DirectiveBase {
 // فقط lazyInit_ — بدون onVisible_
 @directive('my-product-price')
 export class ProductPriceDirective extends DirectiveBase {
-  protected init_(): void {
+  protected override init_(): void {
     this.element_.classList.add('loading-skeleton');
   }
 
-  protected async lazyInit_(): Promise<void> {
+  protected override async lazyInit_(): Promise<void> {
     const price = await fetchPrice(this.attributeValue);
     this.element_.classList.remove('loading-skeleton');
     this.element_.textContent = price;
@@ -329,12 +361,15 @@ export class ProductPriceDirective extends DirectiveBase {
 
 - **lazyInit single execution**: `lazyInit_()` برای هر instance دقیقاً یک بار اجرا می‌شود
 - **onVisible repeated execution**: `onVisible_()` هر بار که element وارد viewport شود اجرا می‌شود
-- **Order guarantee**: هر دو hook همیشه پس از تکمیل `init_()` اجرا می‌شوند
+- **onHidden repeated execution**: `onHidden_()` هر بار که element از viewport خارج شود اجرا می‌شود
+- **Shared observer**: `onVisible_` و `onHidden_` یک `IntersectionObserver` مشترک دارند
+- **Order guarantee**: هر hook همیشه پس از تکمیل `init_()` اجرا می‌شود
 - **Backward compatibility**: directive هایی که هیچ‌کدام از hookها را ندارند رفتار قبلی را حفظ می‌کنند
 - **Error isolation**: خطا در هر hook باعث crash directive یا سایر directive ها نمی‌شود
-- **No memory leak**: observer های `lazyInit_` و `onVisible_` هر دو در `destroyHookList__` ثبت می‌شوند
+- **No memory leak**: observer های `lazyInit_` و visibility هر دو در `destroyHookList__` ثبت می‌شوند
 - **lazyInit fallback chain**: `IntersectionObserver` → `requestIdleCallback` → `setTimeout(100ms)`
-- **onVisible fallback**: `IntersectionObserver` → یک بار اجرای فوری
+- **onVisible fallback**: `IntersectionObserver` → یک بار با `setTimeout(100ms)`
+- **onHidden fallback**: ندارد — در محیط بدون `IntersectionObserver` اجرا نمی‌شود
 
 ---
 
@@ -376,7 +411,7 @@ export class ProductPriceDirective extends DirectiveBase {
 ### Integration Testing
 
 - `IntersectionObserver` mock: element وارد viewport شود → `lazyInit_` یک بار، `onVisible_` هر بار اجرا شود
-- `IntersectionObserver` غیرفعال: `lazyInit_` از fallback chain استفاده کند، `onVisible_` یک بار فوری اجرا شود
+- `IntersectionObserver` غیرفعال: `lazyInit_` از fallback chain استفاده کند، `onVisible_` یک بار با `setTimeout(100ms)` اجرا شود
 - `destroy()` قبل از intersection: هیچ hookی اجرا نشود
 
 ---

--- a/.kiro/specs/lazy-init-directive/requirements.md
+++ b/.kiro/specs/lazy-init-directive/requirements.md
@@ -2,12 +2,15 @@
 
 ## Introduction
 
-این فیچر دو lifecycle hook اختیاری به کلاس `DirectiveBase` در پکیج `@alwatr/directive` اضافه می‌کند:
+این فیچر سه lifecycle hook اختیاری به کلاس `DirectiveBase` در پکیج `@alwatr/directive` اضافه می‌کند:
 
 - **`lazyInit_()`**: دقیقاً یک بار، اولین باری که element وارد viewport شود اجرا می‌شود.
 - **`onVisible_()`**: هر بار که element وارد viewport شود اجرا می‌شود.
+- **`onHidden_()`**: هر بار که element از viewport خارج شود اجرا می‌شود.
 
-هر دو hook با `IntersectionObserver` پیاده‌سازی می‌شوند و در صورت عدم پشتیبانی مرورگر، fallback مناسب دارند. این قابلیت‌ها برای lazy loading، impression tracking و animation restart طراحی شده‌اند.
+همچنین `init_()` به optional تبدیل شده تا directive هایی که فقط از `@on` decorator یا visibility hook استفاده می‌کنند نیازی به تعریف آن نداشته باشند.
+
+هر سه hook با `IntersectionObserver` پیاده‌سازی می‌شوند و در صورت عدم پشتیبانی مرورگر، fallback مناسب دارند. این قابلیت‌ها برای lazy loading، impression tracking، animation restart و pause/resume طراحی شده‌اند.
 
 ---
 
@@ -17,8 +20,9 @@
 - **Directive**: یک کلاس که رفتار سفارشی را به یک HTML element متصل می‌کند.
 - **lazyInit\_**: lifecycle hook اختیاری که دقیقاً یک بار پس از ورود اول element به viewport اجرا می‌شود.
 - **onVisible\_**: lifecycle hook اختیاری که هر بار پس از ورود element به viewport اجرا می‌شود.
+- **onHidden\_**: lifecycle hook اختیاری که هر بار پس از خروج element از viewport اجرا می‌شود.
 - **triggerLazyInit\_**: متد private که منطق راه‌اندازی one-shot lazy execution را مدیریت می‌کند.
-- **triggerOnVisible\_**: متد private که منطق persistent visibility tracking را مدیریت می‌کند.
+- **triggerVisibilityObserver\_**: متد private که یک `IntersectionObserver` مشترک برای `onVisible_` و `onHidden_` می‌سازد.
 - **IntersectionObserver**: Web API استاندارد برای تشخیص ورود/خروج element به viewport.
 - **destroyHookList\_\_**: لیست داخلی در `DirectiveBase` که cleanup callback ها را نگه می‌دارد و هنگام `destroy()` اجرا می‌شوند.
 - **Viewport**: ناحیه قابل مشاهده مرورگر.
@@ -31,26 +35,28 @@
 
 ### Requirement 1: تعریف lifecycle hook های اختیاری
 
-**User Story:** As a directive developer, I want to define optional `lazyInit_` and `onVisible_` hooks in my directive class, so that I can execute logic at the right time relative to element visibility.
+**User Story:** As a directive developer, I want to define optional `lazyInit_`, `onVisible_`, and `onHidden_` hooks in my directive class, so that I can execute logic at the right time relative to element visibility.
 
 #### Acceptance Criteria
 
-1. THE DirectiveBase SHALL support an optional protected method `lazyInit_()` with return type `Awaitable<void>`.
-2. THE DirectiveBase SHALL support an optional protected method `onVisible_()` with return type `Awaitable<void>`.
-3. WHEN a subclass does not define `lazyInit_`, THE DirectiveBase SHALL not call `triggerLazyInit_()`.
-4. WHEN a subclass does not define `onVisible_`, THE DirectiveBase SHALL not call `triggerOnVisible_()`.
+1. THE DirectiveBase SHALL support an optional protected method `init_()` with return type `Awaitable<void>`.
+2. THE DirectiveBase SHALL support an optional protected method `lazyInit_()` with return type `Awaitable<void>`.
+3. THE DirectiveBase SHALL support an optional protected method `onVisible_()` with return type `Awaitable<void>`.
+4. THE DirectiveBase SHALL support an optional protected method `onHidden_()` with return type `Awaitable<void>`.
+5. WHEN a subclass does not define `lazyInit_`, THE DirectiveBase SHALL not call `triggerLazyInit_()`.
+6. WHEN a subclass defines neither `onVisible_` nor `onHidden_`, THE DirectiveBase SHALL not call `triggerVisibilityObserver_()`.
 
 ---
 
-### Requirement 2: اجرای `lazyInit_` پس از `init_()`
+### Requirement 2: اجرای hookها پس از `init_()`
 
-**User Story:** As a directive developer, I want `lazyInit_` to always run after `init_()` completes, so that my lazy initialization logic can safely depend on the initial setup.
+**User Story:** As a directive developer, I want all visibility hooks to always run after `init_()` completes, so that my logic can safely depend on the initial setup.
 
 #### Acceptance Criteria
 
 1. WHEN `lazyInit_` is defined, THE DirectiveBase SHALL call `triggerLazyInit_()` only after `init_()` has completed.
-2. WHEN `onVisible_` is defined, THE DirectiveBase SHALL call `triggerOnVisible_()` only after `init_()` has completed.
-3. THE DirectiveBase SHALL call both `triggerLazyInit_()` and `triggerOnVisible_()` after `delay.nextMacrotask()` has resolved.
+2. WHEN `onVisible_` or `onHidden_` is defined, THE DirectiveBase SHALL call `triggerVisibilityObserver_()` only after `init_()` has completed.
+3. THE DirectiveBase SHALL call all trigger methods after `delay.nextMacrotask()` has resolved.
 
 ---
 
@@ -66,15 +72,17 @@
 
 ---
 
-### Requirement 4: اجرای تکرارشونده `onVisible_`
+### Requirement 4: اجرای تکرارشونده `onVisible_` و `onHidden_`
 
-**User Story:** As a directive developer, I want `onVisible_` to run every time the element enters the viewport, so that I can track impressions or restart animations on each appearance.
+**User Story:** As a directive developer, I want `onVisible_` to run every time the element enters the viewport and `onHidden_` to run every time it leaves, so that I can track impressions, restart animations, or pause/resume work on each visibility change.
 
 #### Acceptance Criteria
 
-1. WHEN the element enters the viewport, THE DirectiveBase SHALL call `onVisible_()`.
+1. WHEN the element enters the viewport, THE DirectiveBase SHALL call `onVisible_()` if defined.
 2. WHEN the element enters the viewport multiple times, THE DirectiveBase SHALL call `onVisible_()` each time.
-3. WHEN `IntersectionObserver` is available and `onVisible_` is defined, THE triggerOnVisible\_ SHALL create a persistent `IntersectionObserver` that remains active until `destroy()` is called.
+3. WHEN the element leaves the viewport, THE DirectiveBase SHALL call `onHidden_()` if defined.
+4. WHEN the element leaves the viewport multiple times, THE DirectiveBase SHALL call `onHidden_()` each time.
+5. WHEN `IntersectionObserver` is available and either `onVisible_` or `onHidden_` is defined, THE triggerVisibilityObserver\_ SHALL create a single persistent `IntersectionObserver` shared by both hooks, that remains active until `destroy()` is called.
 
 ---
 
@@ -90,14 +98,15 @@
 
 ---
 
-### Requirement 6: Fallback برای `onVisible_`
+### Requirement 6: Fallback برای `onVisible_` و `onHidden_`
 
-**User Story:** As a directive developer, I want `onVisible_` to execute at least once even in environments without `IntersectionObserver`, so that critical visibility logic is not silently skipped.
+**User Story:** As a directive developer, I want `onVisible_` to execute at least once even in environments without `IntersectionObserver`, so that critical visibility logic is not silently skipped. I accept that `onHidden_` has no meaningful fallback.
 
 #### Acceptance Criteria
 
-1. WHEN `IntersectionObserver` is not available and `onVisible_` is defined, THE triggerOnVisible* SHALL call `onVisible*()` exactly once immediately.
-2. WHEN `IntersectionObserver` is available, THE triggerOnVisible* SHALL use `IntersectionObserver` and SHALL NOT call `onVisible*()` immediately without an intersection event.
+1. WHEN `IntersectionObserver` is not available and `onVisible_` is defined, THE triggerVisibilityObserver\_ SHALL schedule `onVisible_()` exactly once via `setTimeout` with a 100ms delay.
+2. WHEN `IntersectionObserver` is not available and `onHidden_` is defined, THE triggerVisibilityObserver\_ SHALL NOT call `onHidden_()` — no fallback exists.
+3. WHEN `IntersectionObserver` is available, THE triggerVisibilityObserver\_ SHALL use `IntersectionObserver` and SHALL NOT call either hook immediately without an intersection event.
 
 ---
 
@@ -108,31 +117,31 @@
 #### Acceptance Criteria
 
 1. WHEN `IntersectionObserver` is used for `lazyInit_`, THE triggerLazyInit\_ SHALL register the observer's `disconnect` method in `destroyHookList__`.
-2. WHEN `IntersectionObserver` is used for `onVisible_`, THE triggerOnVisible\_ SHALL register the observer's `disconnect` method in `destroyHookList__`.
+2. WHEN `IntersectionObserver` is used for `onVisible_` or `onHidden_`, THE triggerVisibilityObserver\_ SHALL register the shared observer's `disconnect` method once in `destroyHookList__`.
 3. WHEN `destroy()` is called before the element enters the viewport, THE DirectiveBase SHALL disconnect the `lazyInit_` observer without calling `lazyInit_()`.
-4. WHEN `destroy()` is called, THE DirectiveBase SHALL disconnect the `onVisible_` observer and SHALL NOT call `onVisible_()` after destruction.
+4. WHEN `destroy()` is called, THE DirectiveBase SHALL disconnect the visibility observer and SHALL NOT call `onVisible_()` or `onHidden_()` after destruction.
 
 ---
 
 ### Requirement 8: Error isolation در hookها
 
-**User Story:** As a directive developer, I want errors thrown inside `lazyInit_` or `onVisible_` to be caught and logged without crashing the directive, so that a bug in one hook does not break the entire directive or other directives.
+**User Story:** As a directive developer, I want errors thrown inside any hook to be caught and logged without crashing the directive, so that a bug in one hook does not break the entire directive or other directives.
 
 #### Acceptance Criteria
 
 1. WHEN `lazyInit_()` throws an error, THE DirectiveBase SHALL log the error using `logger_.error` with the method name and error key.
 2. WHEN `onVisible_()` throws an error, THE DirectiveBase SHALL log the error using `logger_.error` with the method name and error key.
-3. WHEN an error occurs in `lazyInit_()`, THE DirectiveBase SHALL continue normal operation without re-throwing the exception.
-4. WHEN an error occurs in `onVisible_()`, THE DirectiveBase SHALL continue normal operation without re-throwing the exception.
+3. WHEN `onHidden_()` throws an error, THE DirectiveBase SHALL log the error using `logger_.error` with the method name and error key.
+4. WHEN an error occurs in any hook, THE DirectiveBase SHALL continue normal operation without re-throwing the exception.
 
 ---
 
 ### Requirement 9: Backward compatibility
 
-**User Story:** As an existing directive developer, I want directives that don't define `lazyInit_` or `onVisible_` to behave exactly as before, so that adopting this feature is non-breaking.
+**User Story:** As an existing directive developer, I want directives that don't define any visibility hooks to behave exactly as before, so that adopting this feature is non-breaking.
 
 #### Acceptance Criteria
 
-1. WHEN a directive subclass defines neither `lazyInit_` nor `onVisible_`, THE DirectiveBase SHALL behave identically to its previous implementation.
-2. THE DirectiveBase SHALL not create any `IntersectionObserver` instance when neither `lazyInit_` nor `onVisible_` is defined.
-3. THE DirectiveBase SHALL not register any additional entries in `destroyHookList__` when neither hook is defined.
+1. WHEN a directive subclass defines none of `lazyInit_`, `onVisible_`, or `onHidden_`, THE DirectiveBase SHALL behave identically to its previous implementation.
+2. THE DirectiveBase SHALL not create any `IntersectionObserver` instance when none of the visibility hooks are defined.
+3. THE DirectiveBase SHALL not register any additional entries in `destroyHookList__` when none of the visibility hooks are defined.

--- a/.kiro/specs/lazy-init-directive/tasks.md
+++ b/.kiro/specs/lazy-init-directive/tasks.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-افزودن دو lifecycle hook اختیاری `lazyInit_` و `onVisible_` به کلاس `DirectiveBase` در فایل `pkg/nanolib/directive/src/directive-class.ts`. پیاده‌سازی با `IntersectionObserver` انجام می‌شود و fallback chain مناسب برای محیط‌های بدون پشتیبانی دارد.
+افزودن lifecycle hook های اختیاری `lazyInit_`، `onVisible_` و `onHidden_` به کلاس `DirectiveBase` در فایل `pkg/nanolib/directive/src/directive-class.ts`. همچنین `init_` به optional تبدیل شده. پیاده‌سازی با `IntersectionObserver` انجام می‌شود. `onVisible_` و `onHidden_` یک observer مشترک دارند.
 
 ## Tasks
 
@@ -95,9 +95,27 @@
 
 - [x] 8. به‌روزرسانی README
   - فایل `pkg/nanolib/directive/README.md` را به‌روز کن
-  - مستندسازی دو hook جدید `lazyInit_` و `onVisible_` با توضیح کارکرد هر کدام
+  - مستندسازی hook های جدید `lazyInit_`، `onVisible_` و `onHidden_` با توضیح کارکرد هر کدام
   - مثال کد برای هر hook نشان بده
   - fallback chain برای `lazyInit_` را توضیح بده (`IntersectionObserver` → `requestIdleCallback` → `setTimeout`)
   - رفتار `onVisible_` در محیط بدون `IntersectionObserver` را توضیح بده
+  - رفتار `onHidden_` (بدون fallback) را توضیح بده
   - نحوه تعامل با `destroy()` و cleanup را مستند کن
-  - _Requirements: 1.1, 1.2, 1.3, 1.4, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3, 6.1, 6.2_
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 4.4, 4.5, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3_
+
+- [x] 9. پیاده‌سازی `onHidden_` و یکپارچه‌سازی با `onVisible_`
+  - [x] 9.1 اضافه کردن تعریف نوع `onHidden_` به `DirectiveBase`
+    - در `directive-class.ts`، متد optional protected اضافه شد:
+      - `protected onHidden_?(): Awaitable<void>`
+    - _Requirements: 1.4_
+  - [x] 9.2 تبدیل `triggerOnVisible_` به `triggerVisibilityObserver_`
+    - متد `triggerOnVisible_` به `triggerVisibilityObserver_` تغییر نام یافت
+    - observer مشترک برای هر دو hook ساخته شد
+    - در `initializeLifecycle_`، شرط به `if (this.onVisible_ || this.onHidden_)` تغییر یافت
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 6.1, 6.2, 6.3, 7.2, 7.4, 8.3, 8.4_
+  - [ ] 9.3 نوشتن تست‌های unit برای `onHidden_`
+    - تست کن: وقتی `onHidden_` تعریف شده، هر بار خروج از viewport اجرا شود
+    - تست کن: وقتی `onHidden_()` خطا پرتاب کند، directive crash نکند
+    - تست کن: وقتی `destroy()` فراخوانی شود، `onHidden_()` دیگر اجرا نشود
+    - تست کن: `onVisible_` و `onHidden_` یک observer مشترک دارند (نه دو observer جداگانه)
+    - _Requirements: 4.3, 4.4, 7.2, 7.4, 8.3, 8.4_

--- a/pkg/nanolib/directive/README.md
+++ b/pkg/nanolib/directive/README.md
@@ -173,12 +173,13 @@ new DirectiveBase(element, attributeName)
   └─ after one macrotask (delay.nextMacrotask)
        ├─ init_()?       ← optional — runs once (setup, event listeners)
        ├─ lazyInit_()?   ← optional — runs once, when element first enters viewport
-       └─ onVisible_()?  ← optional — runs every time element enters viewport
+       ├─ onVisible_()?  ← optional — runs every time element enters viewport
+       └─ onHidden_()?   ← optional — runs every time element leaves viewport
 ```
 
 The macrotask delay ensures the full DOM subtree is painted and settled before your directive runs — no race conditions with sibling elements or CSS.
 
-All three hooks are **optional**. You only define the ones you need — a directive that only uses `@on` decorators doesn't need any hook at all.
+All four hooks are **optional**. You only define the ones you need — a directive that only uses `@on` decorators doesn't need any hook at all.
 
 ---
 
@@ -223,7 +224,7 @@ class ProductImageDirective extends DirectiveBase {
 
 Runs **every time** the element enters the viewport. Ideal for impression tracking, restarting animations, or refreshing dynamic data on each appearance.
 
-**Fallback** (when `IntersectionObserver` is unavailable): `onVisible_()` is called once immediately at setup time, so critical visibility logic is never silently skipped.
+**Fallback** (when `IntersectionObserver` is unavailable): `onVisible_()` is scheduled once via `setTimeout(100ms)` at setup time, so critical visibility logic is never silently skipped while avoiding a performance hit at startup.
 
 ```typescript
 @directive('track-impression')
@@ -238,6 +239,39 @@ class ImpressionTrackerDirective extends DirectiveBase {
 ```html
 <div track-impression="banner-hero">...</div>
 ```
+
+### `onHidden_()`
+
+Runs **every time** the element leaves the viewport. The counterpart to `onVisible_()`.
+
+**Fallback**: no fallback — if `IntersectionObserver` is unavailable, this hook is never called. Design your directive to work correctly without it.
+
+```typescript
+@directive('auto-pause-video')
+class AutoPauseVideoDirective extends DirectiveBase {
+  private video_!: HTMLVideoElement;
+
+  protected override init_(): void {
+    this.video_ = this.element_.querySelector('video')!;
+  }
+
+  protected override onVisible_(): void {
+    void this.video_.play();
+  }
+
+  protected override onHidden_(): void {
+    this.video_.pause();
+  }
+}
+```
+
+```html
+<div auto-pause-video>
+  <video src="clip.mp4"></video>
+</div>
+```
+
+> **Note:** `onVisible_` and `onHidden_` share a single `IntersectionObserver` instance — no duplicate observers are created when both are defined.
 
 ### Using both hooks together
 
@@ -268,22 +302,23 @@ class ProductCardDirective extends DirectiveBase {
 
 ### Cleanup & `destroy()`
 
-Both hooks register their `IntersectionObserver` in `destroyHookList__` automatically. When `destroy()` is called:
+All visibility hooks register their `IntersectionObserver` in `destroyHookList__` automatically. `onVisible_` and `onHidden_` share a single observer, so only one entry is added. When `destroy()` is called:
 
 - The `lazyInit_` observer is disconnected — if the element hasn't entered the viewport yet, `lazyInit_()` will **not** run.
-- The `onVisible_` observer is disconnected — `onVisible_()` will **not** fire after destruction.
+- The shared `onVisible_`/`onHidden_` observer is disconnected — neither hook will fire after destruction.
 
 No manual cleanup is needed. No memory leaks.
 
 ### Hook comparison
 
-|                    | `init_()?`             | `lazyInit_()?`                      | `onVisible_()?`                        |
-| ------------------ | ---------------------- | ----------------------------------- | -------------------------------------- |
-| **When**           | After next macrotask   | First viewport entry                | Every viewport entry                   |
-| **Times**          | Once                   | Once                                | Unlimited                              |
-| **Good for**       | Event listeners, setup | Lazy loading, data fetch            | Impression tracking, animation restart |
-| **Auto cleanup**   | —                      | ✅ observer disconnected on destroy | ✅ observer disconnected on destroy    |
-| **Error handling** | —                      | ✅ logged, never re-thrown          | ✅ logged, never re-thrown             |
+|                    | `init_()?`             | `lazyInit_()?`                       | `onVisible_()?`                        | `onHidden_()?`                    |
+| ------------------ | ---------------------- | ------------------------------------ | -------------------------------------- | --------------------------------- |
+| **When**           | After next macrotask   | First viewport entry                 | Every viewport entry                   | Every viewport exit               |
+| **Times**          | Once                   | Once                                 | Unlimited                              | Unlimited                         |
+| **Good for**       | Event listeners, setup | Lazy loading, data fetch             | Impression tracking, animation restart | Pause video, cancel work, hide UI |
+| **Auto cleanup**   | —                      | ✅ observer disconnected on destroy  | ✅ shared observer, disconnected       | ✅ shared observer, disconnected  |
+| **Error handling** | —                      | ✅ logged, never re-thrown           | ✅ logged, never re-thrown             | ✅ logged, never re-thrown        |
+| **Fallback**       | —                      | `requestIdleCallback` → `setTimeout` | Called once via `setTimeout(100ms)`    | None — silently skipped           |
 
 ---
 
@@ -487,6 +522,7 @@ Class decorator. Registers the decorated class in the global directive registry.
 | `init_()?`                 | `protected`                      | Optional — runs once after next macrotask (setup, event listeners) |
 | `lazyInit_()?`             | `protected`                      | Optional — runs once when element first enters the viewport        |
 | `onVisible_()?`            | `protected`                      | Optional — runs every time element enters the viewport             |
+| `onHidden_()?`             | `protected`                      | Optional — runs every time element leaves the viewport             |
 | `dispatch(event, detail?)` | `public`                         | Fires a bubbling `CustomEvent` from `element_`                     |
 | `addDestroyHook(task)`     | `public`                         | Registers an async cleanup callback                                |
 | `destroy()`                | `public async`                   | Runs all destroy hooks, then nullifies `element_`                  |

--- a/pkg/nanolib/directive/package.json
+++ b/pkg/nanolib/directive/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "nano-build --preset=module-web src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -186,15 +186,24 @@ export abstract class DirectiveBase {
       }
     };
 
+    const executeOnHidden_ = async () => {
+      try {
+        if (this.isDestroyed()) return;
+        await this.onHidden_?.();
+      } catch (err) {
+        this.logger_.error('triggerVisibilityObserver_', 'error_in_on_hidden', err);
+      }
+    };
+
     if (typeof IntersectionObserver !== 'undefined') {
-      const observer = new IntersectionObserver(async (entries) => {
+      const observer = new IntersectionObserver((entries) => {
         if (this.isDestroyed()) return;
         const entry = entries[0];
         if (entry.isIntersecting) {
           void executeOnVisible_();
         } else {
           try {
-            await this.onHidden_?.();
+            void executeOnHidden_();
           } catch (err) {
             this.logger_.error('triggerVisibilityObserver_', 'error_in_on_hidden', err);
           }
@@ -203,7 +212,7 @@ export abstract class DirectiveBase {
       observer.observe(this.element_);
       this.addDestroyHook(() => observer.disconnect());
     } else if (this.onVisible_) {
-      // Fallback: run onVisible_ once immediately. onHidden_ has no meaningful fallback.
+      // Fallback: run onVisible_ once after 100ms. onHidden_ has no meaningful fallback.
       setTimeout(() => void executeOnVisible_(), 100);
     }
   }

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -106,8 +106,8 @@ export abstract class DirectiveBase {
     if (this.lazyInit_) {
       this.triggerLazyInit_();
     }
-    if (this.onVisible_) {
-      this.triggerOnVisible_();
+    if (this.onVisible_ || this.onHidden_) {
+      this.triggerVisibilityObserver_();
     }
   }
 
@@ -132,6 +132,14 @@ export abstract class DirectiveBase {
    * Use for: impression tracking, restarting animations, refreshing dynamic data.
    */
   protected onVisible_?(): Awaitable<void>;
+
+  /**
+   * Optional lifecycle hook — runs **every time** the element leaves the viewport.
+   * No fallback — if `IntersectionObserver` is unavailable, this hook is never called.
+   *
+   * Use for: pausing animations, stopping video playback, cancelling in-progress work.
+   */
+  protected onHidden_?(): Awaitable<void>;
 
   /**
    * Handles one-shot lazy execution with environment-aware fallbacks.
@@ -165,28 +173,38 @@ export abstract class DirectiveBase {
 
   /**
    * Handles persistent visibility tracking with destroy-safe cleanup.
-   * Uses IntersectionObserver when available, falls back to a single immediate execution.
+   * A single IntersectionObserver handles both onVisible_ and onHidden_ to avoid duplicate observers.
+   * Falls back to a single immediate onVisible_ execution if IntersectionObserver is unavailable.
    */
-  private triggerOnVisible_(): void {
-    const execute = async () => {
+  private triggerVisibilityObserver_(): void {
+    const executeOnVisible_ = async () => {
       try {
         if (this.isDestroyed()) return;
-        await this.onVisible_!();
+        await this.onVisible_?.();
       } catch (err) {
-        this.logger_.error('triggerOnVisible_', 'error_in_on_visible', err);
+        this.logger_.error('triggerVisibilityObserver_', 'error_in_on_visible', err);
       }
     };
 
     if (typeof IntersectionObserver !== 'undefined') {
-      const observer = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting) {
-          void execute();
+      const observer = new IntersectionObserver(async (entries) => {
+        if (this.isDestroyed()) return;
+        const entry = entries[0];
+        if (entry.isIntersecting) {
+          void executeOnVisible_();
+        } else {
+          try {
+            await this.onHidden_?.();
+          } catch (err) {
+            this.logger_.error('triggerVisibilityObserver_', 'error_in_on_hidden', err);
+          }
         }
       });
       observer.observe(this.element_);
       this.addDestroyHook(() => observer.disconnect());
-    } else {
-      setTimeout(() => void execute(), 100);
+    } else if (this.onVisible_) {
+      // Fallback: run onVisible_ once immediately. onHidden_ has no meaningful fallback.
+      setTimeout(() => void executeOnVisible_(), 100);
     }
   }
 

--- a/pkg/nanolib/directive/src/util-decorators.test.ts
+++ b/pkg/nanolib/directive/src/util-decorators.test.ts
@@ -267,4 +267,64 @@ describe('@on', () => {
     // Handler was never registered, so it should not have been called
     expect(callCount).toBe(0);
   });
+
+  it('works correctly when addInitializer fires AFTER constructor (Bun bundler bug simulation)', () => {
+    // Bun bundler emits __runInitializers inside the constructor body *before*
+    // __decorateElement has registered the initializers. This means context.addInitializer
+    // callbacks are silently skipped in browser builds.
+    //
+    // This test simulates that broken ordering by manually applying the decorator
+    // *after* the instance is already constructed — if the implementation relied solely
+    // on context.addInitializer, the listener would never be registered.
+    let callCount = 0;
+
+    // Step 1: define a plain class WITHOUT @on (no decorator at class-definition time)
+    class LateDecoratedDirective extends DirectiveBase {
+      protected init_(): void {}
+
+      // This method will have @on applied manually AFTER instantiation (simulating the bug)
+      onLateClick(_e: Event): void {
+        callCount++;
+      }
+    }
+
+    // Step 2: apply the @on decorator manually to the method function, populating onEntriesWeakMap
+    const decorator = on('click');
+    const addInitializerCalls: Array<(this: DirectiveBase) => void> = [];
+    decorator(LateDecoratedDirective.prototype.onLateClick, {
+      kind: 'method',
+      name: 'onLateClick',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      metadata: {} as any,
+      access: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        has: () => false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        get: () => undefined as any,
+      },
+      addInitializer(fn) {
+        // Collect but do NOT call — simulates Bun bundler running __runInitializers
+        // before __decorateElement has had a chance to register anything.
+        addInitializerCalls.push(fn);
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    // Step 3: construct the instance — at this point addInitializer callbacks have NOT run
+    // (simulating the Bun bundler bug where __runInitializers fires before __decorateElement)
+    const root = document.createElement('div');
+    const instance = new LateDecoratedDirective(root, 'test');
+
+    // Step 4: dispatch the event — the listener should be registered via the WeakMap path
+    // in DirectiveBase.runOnEntries_(), NOT via addInitializer
+    root.dispatchEvent(new Event('click'));
+    expect(callCount).toBe(1);
+
+    // Verify that addInitializer was indeed never called (confirming we tested the right path)
+    expect(addInitializerCalls.length).toBe(1); // registered but not called
+    // If we now call them (simulating correct runtime), it would double-register — but we don't
+
+    // Cleanup
+    void instance.destroy();
+  });
 });

--- a/pkg/nanolib/directive/src/util-decorators.ts
+++ b/pkg/nanolib/directive/src/util-decorators.ts
@@ -184,6 +184,7 @@ export function on(
     }
 
     context.addInitializer(function (this: DirectiveBase) {
+      this.logger_.logMethodArgs?.('@on-init', {eventType, selector, options});
       const targetElement = selector ? this.element_.querySelector(selector) : this.element_;
 
       if (selector && targetElement === null) {

--- a/pkg/nanolib/is-number/src/main.ts
+++ b/pkg/nanolib/is-number/src/main.ts
@@ -38,7 +38,7 @@ export function isFiniteNumber(value: unknown): value is number {
  * isNumber(undefined);  // false
  * ```
  */
-export function isNumber(value: unknown): value is number {
+export function isNumber(value: unknown): boolean {
   // Handle number type
   if (typeof value === 'number') {
     return value - value === 0;

--- a/pkg/nanolib/nano-build/cli.sh
+++ b/pkg/nanolib/nano-build/cli.sh
@@ -104,6 +104,19 @@ case "$preset" in
     fi
   ;;
 
+  module-web)
+    args+=(
+      '--target=browser'
+      '--sourcemap=linked'
+      '--format=esm'
+    )
+
+    if ! $hasPackages; then
+      hasPackages=true
+      args+=('--packages=external')
+    fi
+  ;;
+
   web)
     args+=(
       '--target=browser'

--- a/pkg/nanolib/on/package.json
+++ b/pkg/nanolib/on/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "nano-build --preset=module-web src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",


### PR DESCRIPTION
## Description

Add `onHidden_()` and update `onVisible_()` lifecycle hooks to improve visibility management in directives. Introduce a unified `triggerVisibilityObserver_()` method to handle both hooks with a shared `IntersectionObserver`. Update documentation to reflect these changes and enhance debugging with logging for event listener initialization. Change `isNumber()` return type for better API flexibility.

