### PR TITLE
Enhance event handling in alwatr-on directive

### DIFF
--- a/.kiro/specs/alwatr-on/design.md
+++ b/.kiro/specs/alwatr-on/design.md
@@ -107,7 +107,7 @@ protected dispatch_(event: Event): void
 
 **Postconditions:**
 
-- `event.preventDefault()` is called via optional chaining (`event?.preventDefault()`)
+- event.preventDefault() is called
 - `actionId` is `this.match[2]`
 - `actionPayload` is resolved:
   - `(this.element_ as {value: string}).value` if `this.match[3] === '$value'` and `'value' in this.element_`

--- a/.kiro/specs/alwatr-on/design.md
+++ b/.kiro/specs/alwatr-on/design.md
@@ -20,9 +20,9 @@ sequenceDiagram
     Dir->>HTML: addEventListener(eventType, dispatch_)
     HTML->>Dir: user triggers DOM event (e.g. click)
     Dir->>Dir: dispatch_() — resolve actionPayload ($value or literal)
-    Dir->>Sig: eventSignal_.dispatch({actionId, actionPayload})
+    Dir->>Sig: eventSignal_.dispatch({actionId, actionPayload, event})
     Sig-->>App: alwatrOn('open-drawer', handler) callback fires
-    App->>App: handler('main')
+    App->>App: handler('main', MouseEvent)
 ```
 
 Special case — `init` event type:
@@ -30,11 +30,14 @@ Special case — `init` event type:
 ```mermaid
 sequenceDiagram
     participant Dir as AlwatrActionDirective
+    participant El as element_ (HTMLElement)
     participant Sig as eventSignal_
 
     Dir->>Dir: init_() detects eventType === 'init'
-    Dir->>Sig: dispatch_() immediately
-    Dir->>Dir: destroy() — one-shot, no listener registered
+    Dir->>El: element_.dispatchEvent(new CustomEvent('init', {bubbles:false}))
+    Note over El: synthetic event — target = element_, type = 'init'
+    Dir->>Sig: dispatch_(syntheticEvent) — one-shot
+    Dir->>Dir: destroy() — no persistent listener registered
 ```
 
 ---
@@ -48,6 +51,17 @@ interface ActionPayload {
   actionId: string;
   /** Arbitrary string value forwarded to the handler. */
   actionPayload: string;
+  /**
+   * The DOM event that triggered this dispatch.
+   *
+   * For standard DOM event types (e.g. 'click', 'input'), this is the original browser Event.
+   * For the special 'init' event type, this is a synthetic CustomEvent dispatched on the element
+   * via `element_.dispatchEvent(new CustomEvent('init', {bubbles: false, cancelable: false}))`,
+   * so `event.target === element_` and `event.type === 'init'`.
+   *
+   * The field is always present — never undefined.
+   */
+  event: Event;
 }
 
 /** Return value of alwatrOn — wraps the signal subscription. */
@@ -79,26 +93,27 @@ protected init_(): void
 
 ---
 
-### `AlwatrActionDirective.dispatch_(event?)`
+### `AlwatrActionDirective.dispatch_(event)`
 
 ```typescript
-protected dispatch_(event?: Event): void
+protected dispatch_(event: Event): void
 ```
 
 **Preconditions:**
 
 - `this.match` is non-null (guaranteed by `init_` guard)
 - `this.element_` is a connected `HTMLElement`
+- `event` is always a valid `Event` instance (real DOM event or synthetic `CustomEvent('init')`)
 
 **Postconditions:**
 
-- `event.preventDefault()` is called when `event` is provided
+- `event.preventDefault()` is called via optional chaining (`event?.preventDefault()`)
 - `actionId` is `this.match[2]`
 - `actionPayload` is resolved:
+  - `(this.element_ as {value: string}).value` if `this.match[3] === '$value'` and `'value' in this.element_`
   - `this.match[3]` if present and not `'$value'`
-  - `(this.element_ as HTMLInputElement).value` if `this.match[3] === '$value'`
   - `''` if `this.match[3]` is absent
-- `eventSignal_.dispatch({actionId, actionPayload})` is called exactly once
+- `eventSignal_.dispatch({actionId, actionPayload, event})` is called exactly once — `event` is always present
 
 **Loop Invariants:** N/A
 
@@ -107,7 +122,7 @@ protected dispatch_(event?: Event): void
 ### `alwatrOn(actionId, handler)`
 
 ```typescript
-function alwatrOn(actionId: string, handler: (payload: string) => void): SubscribeResult;
+function alwatrOn(actionId: string, handler: (payload: string, event: Event) => void): SubscribeResult;
 ```
 
 **Preconditions:**
@@ -118,7 +133,8 @@ function alwatrOn(actionId: string, handler: (payload: string) => void): Subscri
 **Postconditions:**
 
 - Returns a `SubscribeResult` with an `unsubscribe` method
-- `handler` is called with `payload.actionPayload` whenever `eventSignal_` dispatches a payload where `payload.actionId === actionId`
+- `handler` is called with `(payload.actionPayload, payload.event)` whenever `eventSignal_` dispatches a payload where `payload.actionId === actionId`
+- `event` is always a valid `Event` — either a real DOM event or a synthetic `CustomEvent('init')` with `target === element_`
 - `handler` is NOT called for dispatches with a different `actionId`
 - Calling `result.unsubscribe()` stops future invocations of `handler`
 
@@ -161,7 +177,10 @@ BEGIN
   eventType ← match[1]
 
   IF eventType = 'init' THEN
-    dispatch_()
+    // Synthesize a real CustomEvent so event.target = element_ and event.type = 'init'
+    syntheticEvent ← new CustomEvent('init', {bubbles: false, cancelable: false})
+    element_.dispatchEvent(syntheticEvent)
+    dispatch_(syntheticEvent)
     destroy()
     RETURN
   END IF
@@ -175,26 +194,25 @@ END
 ### Action Dispatch
 
 ```pascal
-ALGORITHM dispatch_(directive, event?)
-INPUT: directive with match, element_; optional DOM event
+ALGORITHM dispatch_(directive, event)
+INPUT: directive with match, element_; Event (real or synthetic)
 
 BEGIN
-  IF event ≠ undefined THEN
-    event.preventDefault()
-  END IF
+  // event is always present — real DOM event or synthetic CustomEvent('init')
+  event.preventDefault()
 
   actionId      ← match[2]
   rawPayload    ← match[3]
 
   IF rawPayload = '$value' AND 'value' IN element_ THEN
-    actionPayload ← (element_ AS HTMLInputElement).value
+    actionPayload ← (element_ AS {value: string}).value
   ELSE IF rawPayload ≠ undefined THEN
     actionPayload ← rawPayload
   ELSE
     actionPayload ← ''
   END IF
 
-  eventSignal_.dispatch({actionId, actionPayload})
+  eventSignal_.dispatch({actionId, actionPayload, event})
 END
 ```
 
@@ -202,13 +220,13 @@ END
 
 ```pascal
 ALGORITHM alwatrOn(actionId, handler)
-INPUT: actionId: string, handler: (payload: string) → void
+INPUT: actionId: string, handler: (payload: string, event: Event) → void
 OUTPUT: SubscribeResult
 
 BEGIN
   RETURN eventSignal_.subscribe((payload) →
     IF payload.actionId = actionId THEN
-      handler(payload.actionPayload)
+      handler(payload.actionPayload, payload.event)
     END IF
   )
 END
@@ -220,25 +238,33 @@ END
 
 ```typescript
 import {bootstrapDirectives} from '@alwatr/directive';
-import {alwatrOn} from '@alwatr/on';
-import '@alwatr/on/directive'; // registers AlwatrActionDirective
+import {alwatrOn, registerAlwatrOnDirective} from '@alwatr/on';
+
+registerAlwatrOnDirective();
+bootstrapDirectives();
 
 // HTML: <button alwatr-on="click->open-drawer:main">Open</button>
 // HTML: <input alwatr-on="input->search-query:$value" />
 // HTML: <div alwatr-on="init->page-loaded"></div>
 
-bootstrapDirectives();
-
-// Subscribe to actions
-const sub = alwatrOn('open-drawer', (payload) => {
+// event is always a real Event — never undefined
+const sub = alwatrOn('open-drawer', (payload, event) => {
   console.log('open drawer:', payload); // 'main'
+  console.log('event type:', event.type); // 'click'
+  console.log('target:', event.target); // <button>
 });
 
-alwatrOn('search-query', (query) => {
+alwatrOn('search-query', (query, event) => {
   console.log('search:', query); // live input value
+  console.log('target tag:', (event.target as HTMLElement).tagName); // 'INPUT'
 });
 
-// Cleanup when no longer needed
+// For init — event is a synthetic CustomEvent, target = element_
+alwatrOn('page-loaded', (payload, event) => {
+  console.log('event type:', event.type); // 'init'
+  console.log('target:', event.target); // <div alwatr-on="init->page-loaded">
+});
+
 sub.unsubscribe();
 ```
 
@@ -246,12 +272,92 @@ sub.unsubscribe();
 
 ## Correctness Properties
 
-- **Syntax guard**: For any `attributeValue` that does not match `syntaxRegex`, `init_()` must not register any DOM listener and must not dispatch any signal.
-- **One-shot init**: For `eventType === 'init'`, `dispatch_()` is called exactly once and the directive is immediately destroyed — no persistent listener.
-- **Payload resolution**: `actionPayload` is `''` when `match[3]` is absent, the element's `.value` when `match[3] === '$value'`, and the literal string otherwise.
-- **Listener cleanup**: Every `addEventListener` call in `init_()` has a corresponding `removeEventListener` registered via `addDestroyHook`.
-- **Action isolation**: `alwatrOn(id, handler)` invokes `handler` only when `payload.actionId === id`; other action IDs are silently ignored.
-- **Unsubscribe idempotency**: Calling `result.unsubscribe()` more than once must not throw.
+_A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Syntax Guard — No Side Effects on Invalid Input
+
+_For any_ `attributeValue` string that does not match `syntaxRegex`, calling `init_()` must not register any DOM listener and must not dispatch any signal on `eventSignal_`.
+
+**Validates: Requirements 1.3**
+
+---
+
+### Property 2: Payload Resolution — Absent Segment
+
+_For any_ `attributeValue` that matches `syntaxRegex` without a `:payload` segment, `actionPayload` in the dispatched `ActionPayload` must equal `""` (empty string).
+
+**Validates: Requirements 4.1**
+
+---
+
+### Property 3: Payload Resolution — `$value` Token
+
+_For any_ element with a `.value` property and any `attributeValue` whose `rawPayload` is `"$value"`, `actionPayload` in the dispatched `ActionPayload` must equal `element_.value` at the exact moment `dispatch_()` is called.
+
+**Validates: Requirements 4.2**
+
+---
+
+### Property 4: Payload Resolution — Literal String
+
+_For any_ `attributeValue` whose `rawPayload` is a non-empty string other than `"$value"`, `actionPayload` in the dispatched `ActionPayload` must equal that literal string unchanged.
+
+**Validates: Requirements 4.3**
+
+---
+
+### Property 5: Listener Cleanup — Symmetric addEventListener / removeEventListener
+
+_For any_ directive initialized with a non-`init` `eventType`, every `addEventListener(eventType, dispatch_)` call must have exactly one corresponding `removeEventListener(eventType, dispatch_)` call registered via `addDestroyHook` — no more, no less.
+
+**Validates: Requirements 2.2, 2.3**
+
+---
+
+### Property 6: One-Shot `init` — Synthetic Event with Correct Target
+
+_For any_ `attributeValue` where `eventType === "init"`, `init_()` must:
+
+1. Create a `CustomEvent('init', {bubbles: false, cancelable: false})` and dispatch it on `element_` via `element_.dispatchEvent()`
+2. Call `dispatch_(syntheticEvent)` exactly once with that synthetic event
+3. Call `destroy()` immediately after
+4. Not call `addEventListener` at any point
+
+The resulting `payload.event` in the signal must have `event.type === 'init'` and `event.target === element_`.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+---
+
+### Property 7: Action Isolation — Handler Invoked Only for Matching `actionId`
+
+_For any_ `actionId` string passed to `alwatrOn`, and _for any_ `ActionPayload` dispatched on `eventSignal_` where `payload.actionId !== actionId`, the registered `handler` must not be invoked.
+
+**Validates: Requirements 6.1, 6.3**
+
+---
+
+### Property 8: Unsubscribe Stops Handler Invocations
+
+_For any_ subscription returned by `alwatrOn`, after `result.unsubscribe()` is called, _for any_ subsequent dispatch on `eventSignal_` (regardless of `actionId`), the `handler` must not be invoked.
+
+**Validates: Requirements 6.4**
+
+---
+
+### Property 9: `event.preventDefault()` Called for All DOM-Triggered Dispatches
+
+_For any_ DOM `Event` object passed to `dispatch_()`, `event.preventDefault()` must be called before `eventSignal_.dispatch(...)` is invoked.
+
+**Validates: Requirements 5.1**
+
+---
+
+### Property 10: Event Forwarding — DOM Event Reaches `alwatrOn` Handler
+
+_For any_ `Event` passed to `dispatch_()` (real DOM event or synthetic `CustomEvent('init')`), the same `Event` instance must be present as `payload.event` in the signal and forwarded as the second argument to the matching `alwatrOn` handler. The `event` field is always a valid `Event` — never `undefined`.
+
+**Validates: Requirements 5.2, 6.1**
 
 ---
 

--- a/.kiro/specs/alwatr-on/requirements.md
+++ b/.kiro/specs/alwatr-on/requirements.md
@@ -42,7 +42,7 @@ The package follows the nano-package principle: one responsibility, minimal depe
 1. WHEN `AlwatrActionDirective` is initialized with an `attributeValue`, THE `AlwatrActionDirective` SHALL parse the value against `syntaxRegex` to extract `eventType`, `actionId`, and optional `rawPayload`.
 2. WHEN `attributeValue` matches `syntaxRegex`, THE `AlwatrActionDirective` SHALL store the match result and proceed with initialization.
 3. IF `attributeValue` does not match `syntaxRegex`, THEN THE `AlwatrActionDirective` SHALL call `logger_.accident(...)` and return without registering any DOM listener or dispatching any signal.
-4. THE `syntaxRegex` SHALL be the pattern `/^([a-z]+)->([a-z0-9-]+)(?::(.+))?$/`.
+4. THE syntaxRegex SHALL be the pattern /^([a-z0-9-]+)->([a-z0-9-]+)(?::(.+))?$/.
 
 ---
 

--- a/.kiro/specs/alwatr-on/requirements.md
+++ b/.kiro/specs/alwatr-on/requirements.md
@@ -1,42 +1,123 @@
-# Requirements: `@alwatr/on`
+# Requirements Document: `@alwatr/on`
 
-## Functional Requirements
+## Introduction
 
-### 1. Attribute Syntax Parsing
+`@alwatr/on` is a declarative DOM action-dispatch package that bridges HTML attributes to application-level signal handlers. It provides two primitives:
 
-- **1.1** The directive MUST parse `alwatr-on` attribute values matching the pattern `event->actionId` or `event->actionId:payload`.
-- **1.2** If the attribute value does not match the regex `/^([a-z]+)->([a-z0-9-]+)(?::(.+))?$/`, the directive MUST log an accident and perform no further action.
+1. **`AlwatrActionDirective`** — a `DirectiveBase` subclass that reads `alwatr-on` attributes, parses their syntax, and dispatches typed action signals in response to DOM events.
+2. **`alwatrOn`** — a subscription helper that lets any part of the application react to those actions by `actionId`.
 
-### 2. DOM Event Listening
+The package follows the nano-package principle: one responsibility, minimal dependencies, ESM-only, tree-shakeable.
 
-- **2.1** For any valid `eventType` other than `init`, the directive MUST call `element_.addEventListener(eventType, dispatch_)` during `init_()`.
-- **2.2** The directive MUST register a destroy hook that calls `element_.removeEventListener(eventType, dispatch_)` to prevent memory leaks.
+---
 
-### 3. One-Shot `init` Event
+## Glossary
 
-- **3.1** When `eventType === 'init'`, the directive MUST dispatch the action immediately without registering a DOM listener.
-- **3.2** After dispatching, the directive MUST call `destroy()` so it is cleaned up immediately.
+- **Directive**: A class extending `DirectiveBase` from `@alwatr/directive` that is automatically instantiated for every matching HTML attribute found by `bootstrapDirectives()`.
+- **AlwatrActionDirective**: The directive class registered for the `alwatr-on` HTML attribute.
+- **attributeValue**: The string value of the `alwatr-on` attribute on a DOM element (e.g., `"click->open-drawer:main"`).
+- **syntaxRegex**: The compiled regular expression `/^([a-z]+)->([a-z0-9-]+)(?::(.+))?$/` used to parse `attributeValue`.
+- **eventType**: The first capture group of `syntaxRegex` — the DOM event name (e.g., `"click"`, `"input"`) or the special value `"init"`.
+- **actionId**: The second capture group of `syntaxRegex` — the identifier used to route the action to the correct handler (e.g., `"open-drawer"`).
+- **rawPayload**: The optional third capture group of `syntaxRegex` — either a literal string, the special token `"$value"`, or absent.
+- **actionPayload**: The resolved string value forwarded to the handler. Derived from `rawPayload` at dispatch time.
+- **eventSignal\_**: The module-level singleton `EventSignal` instance shared by all directives and `alwatrOn` subscriptions within the same module load.
+- **ActionPayload**: The TypeScript interface `{ actionId: string; actionPayload: string; event: Event }` carried by `eventSignal_`. The `event` field is always present — never `undefined`.
+- **syntheticEvent**: A `CustomEvent('init', {bubbles: false, cancelable: false})` created and dispatched on `element_` via `element_.dispatchEvent()` when `eventType === "init"`. Ensures `event.target === element_` and `event.type === "init"` so handlers always receive a valid `Event`.
+- **SubscribeResult**: The return type of `eventSignal_.subscribe(...)`, containing an `unsubscribe()` method.
+- **dispatch\_**: The bound method on `AlwatrActionDirective` that resolves `actionPayload` and calls `eventSignal_.dispatch(...)`.
+- **destroy hook**: A callback registered via `addDestroyHook(...)` that is invoked when the directive is destroyed, used to remove DOM event listeners.
+- **init event**: The special `eventType` value `"init"` that causes an immediate one-shot dispatch without registering a persistent DOM listener.
 
-### 4. Action Payload Resolution
+---
 
-- **4.1** If no payload segment is present in the attribute, `actionPayload` MUST be `''`.
-- **4.2** If the payload segment is the literal string `$value` and the element has a `.value` property, `actionPayload` MUST be `element_.value` at dispatch time.
-- **4.3** If the payload segment is any other string, `actionPayload` MUST be that literal string.
+## Requirements
 
-### 5. Signal Dispatch
+### Requirement 1: Attribute Syntax Parsing
 
-- **5.1** On every valid DOM event, the directive MUST call `eventSignal_.dispatch({actionId, actionPayload})`.
-- **5.2** `event.preventDefault()` MUST be called when a DOM `Event` object is passed to `dispatch_()`.
+**User Story:** As a developer, I want to declare DOM-to-action bindings in HTML attributes, so that I can wire up application actions without writing imperative event-listener code.
 
-### 6. `alwatrOn` Subscription Helper
+#### Acceptance Criteria
 
-- **6.1** `alwatrOn(actionId, handler)` MUST subscribe to `eventSignal_` and invoke `handler(payload.actionPayload)` only when `payload.actionId === actionId`.
-- **6.2** `alwatrOn` MUST return a `SubscribeResult` object with an `unsubscribe()` method.
-- **6.3** After `unsubscribe()` is called, `handler` MUST NOT be invoked for subsequent dispatches.
+1. WHEN `AlwatrActionDirective` is initialized with an `attributeValue`, THE `AlwatrActionDirective` SHALL parse the value against `syntaxRegex` to extract `eventType`, `actionId`, and optional `rawPayload`.
+2. WHEN `attributeValue` matches `syntaxRegex`, THE `AlwatrActionDirective` SHALL store the match result and proceed with initialization.
+3. IF `attributeValue` does not match `syntaxRegex`, THEN THE `AlwatrActionDirective` SHALL call `logger_.accident(...)` and return without registering any DOM listener or dispatching any signal.
+4. THE `syntaxRegex` SHALL be the pattern `/^([a-z]+)->([a-z0-9-]+)(?::(.+))?$/`.
 
-## Non-Functional Requirements
+---
 
-- **7.1** The package MUST be published as an ESM module (`"type": "module"`).
-- **7.2** The package MUST follow the same `package.json`, `tsconfig.json`, and build script conventions as other packages in `pkg/nanolib/`.
-- **7.3** The package name MUST be `@alwatr/on`.
-- **7.4** The shared `eventSignal_` instance MUST be module-level (singleton per module load).
+### Requirement 2: DOM Event Listening
+
+**User Story:** As a developer, I want the directive to automatically attach and detach DOM event listeners, so that I do not have to manage listener lifecycle manually.
+
+#### Acceptance Criteria
+
+1. WHEN `eventType` is any valid string other than `"init"`, THE `AlwatrActionDirective` SHALL call `element_.addEventListener(eventType, dispatch_)` during `init_()`.
+2. WHEN `AlwatrActionDirective` registers a DOM listener, THE `AlwatrActionDirective` SHALL register a destroy hook that calls `element_.removeEventListener(eventType, dispatch_)`.
+3. WHILE a destroy hook is registered, THE `AlwatrActionDirective` SHALL ensure that for every `addEventListener` call there is exactly one corresponding `removeEventListener` call registered via `addDestroyHook`.
+
+---
+
+### Requirement 3: One-Shot `init` Event
+
+**User Story:** As a developer, I want to trigger an action immediately when a directive is initialized, so that I can handle page-load or component-mount actions declaratively in HTML — and receive a consistent `Event` object just like any other action handler.
+
+#### Acceptance Criteria
+
+1. WHEN `eventType === "init"`, THE `AlwatrActionDirective` SHALL create a `CustomEvent('init', {bubbles: false, cancelable: false})` and dispatch it on `element_` via `element_.dispatchEvent()`.
+2. WHEN `eventType === "init"`, THE `AlwatrActionDirective` SHALL call `dispatch_(syntheticEvent)` with that synthetic event immediately inside `init_()`, without registering any persistent DOM listener.
+3. WHEN `eventType === "init"`, THE `AlwatrActionDirective` SHALL call `destroy()` immediately after dispatching.
+4. THE synthetic `CustomEvent` for `init` SHALL have `event.target === element_` and `event.type === "init"`, so that `alwatrOn` handlers receive a valid, non-null `Event` object.
+
+---
+
+### Requirement 4: Action Payload Resolution
+
+**User Story:** As a developer, I want to pass static or dynamic payload values through the HTML attribute, so that handlers receive the context they need without additional JavaScript.
+
+#### Acceptance Criteria
+
+1. WHEN `rawPayload` is absent (no `:` segment in `attributeValue`), THE `AlwatrActionDirective` SHALL set `actionPayload` to `""` (empty string).
+2. WHEN `rawPayload` is the literal string `"$value"` and `element_` has a `.value` property, THE `AlwatrActionDirective` SHALL set `actionPayload` to `(element_ as HTMLInputElement).value` at the time `dispatch_()` is called.
+3. WHEN `rawPayload` is the literal string `"$value"` and `element_` does not have a `.value` property, THE `AlwatrActionDirective` SHALL set `actionPayload` to `""` (empty string).
+4. WHEN `rawPayload` is any string other than `"$value"`, THE `AlwatrActionDirective` SHALL set `actionPayload` to that literal string unchanged.
+
+---
+
+### Requirement 5: Signal Dispatch
+
+**User Story:** As a developer, I want DOM events to be translated into typed application signals, so that signal subscribers are decoupled from the DOM.
+
+#### Acceptance Criteria
+
+1. WHEN `dispatch_(event)` is called, THE `AlwatrActionDirective` SHALL call `event.preventDefault()` before dispatching the signal.
+2. WHEN `dispatch_(event)` is called, THE `AlwatrActionDirective` SHALL call `eventSignal_.dispatch({ actionId, actionPayload, event })` exactly once — `event` is always a valid `Event` instance.
+3. THE `AlwatrActionDirective` SHALL set `actionId` in the dispatched payload to the value of `match[2]` from the parsed `syntaxRegex` match.
+
+---
+
+### Requirement 6: `alwatrOn` Subscription Helper
+
+**User Story:** As a developer, I want a simple function to subscribe to specific actions by ID, so that I can react to application actions without coupling to the signal internals.
+
+#### Acceptance Criteria
+
+1. WHEN `alwatrOn(actionId, handler)` is called, THE `alwatrOn` function SHALL subscribe to `eventSignal_` and invoke `handler(payload.actionPayload, payload.event)` only when `payload.actionId === actionId`. The `event` argument is always a valid `Event` — never `undefined`.
+2. WHEN `alwatrOn(actionId, handler)` is called, THE `alwatrOn` function SHALL return a `SubscribeResult` object containing an `unsubscribe()` method.
+3. WHEN `eventSignal_` dispatches a payload where `payload.actionId !== actionId`, THE `alwatrOn` function SHALL NOT invoke `handler`.
+4. WHEN `result.unsubscribe()` is called, THE `alwatrOn` subscription SHALL stop invoking `handler` for all subsequent dispatches.
+5. WHEN `result.unsubscribe()` is called more than once, THE `alwatrOn` subscription SHALL not throw an error.
+
+---
+
+### Requirement 7: Module Structure and Package Conventions
+
+**User Story:** As a maintainer, I want the package to follow the monorepo conventions, so that it integrates seamlessly with the build system and other packages.
+
+#### Acceptance Criteria
+
+1. THE `@alwatr/on` package SHALL be published as an ESM module with `"type": "module"` in `package.json`.
+2. THE `@alwatr/on` package SHALL use `"@alwatr/directive"` and `"@alwatr/signal"` as dependencies declared with `"workspace:*"` version specifiers.
+3. THE `@alwatr/on` package SHALL expose a single public entry point at `src/main.ts` that re-exports all public symbols.
+4. THE `eventSignal_` instance SHALL be module-level (singleton per module load), shared by all `AlwatrActionDirective` instances and all `alwatrOn` subscriptions within the same module.
+5. THE `@alwatr/on` package SHALL follow the same `package.json`, `tsconfig.json`, and build script conventions as other packages in `pkg/nanolib/`.

--- a/.kiro/specs/alwatr-on/tasks.md
+++ b/.kiro/specs/alwatr-on/tasks.md
@@ -4,18 +4,29 @@
 
 - [x] 1. Scaffold package structure
   - [x] 1.1 Create `pkg/nanolib/on/` directory with `src/` subdirectory
-  - [x] 1.2 Create `package.json` following nanolib conventions
-  - [x] 1.3 Create `tsconfig.json` following nanolib conventions
-  - [x] 1.4 Create `LICENSE` (copy from sibling package)
+  - [x] 1.2 Create `package.json` following nanolib conventions (`"type": "module"`, `workspace:*` deps, build scripts) — Req 7.1, 7.2, 7.5
+  - [x] 1.3 Create `tsconfig.json` extending `@alwatr/standard/tsconfig` — Req 7.5
+  - [x] 1.4 Create `LICENSE` (MPL-2.0, copy from sibling package)
 
 - [x] 2. Implement source files
-  - [x] 2.1 Create `src/main.ts` — re-exports directive and `alwatrOn`
-  - [x] 2.2 Create `src/directive.ts` — `AlwatrActionDirective` class
-  - [x] 2.3 Create `src/on.ts` — `alwatrOn` helper and shared `eventSignal_`
+  - [x] 2.1 Create `src/signal.ts` — `EventSignalPayload` interface and module-level `eventSignal_` singleton — Req 7.4
+  - [x] 2.2 Create `src/directive.ts` — `AlwatrActionDirective` class with `syntaxRegex`, `match` field, `init_()`, `dispatch_()`, and `registerAlwatrOnDirective` lazy registration — Req 1, 2, 3, 4, 5
+  - [x] 2.3 Create `src/method.ts` — `alwatrOn(actionId, handler)` subscription helper — Req 6
+  - [x] 2.4 Create `src/main.ts` — re-exports all public symbols from `./method.js` and `./directive.js` — Req 7.3
 
-- [x] 3. Write README.md
-  - [x] 3.1 Document installation, syntax format, `alwatrOn` API, and examples
+- [x] 3. Forward DOM event through signal (event access in `alwatrOn`)
+  - [x] 3.1 Update `EventSignalPayload` in `src/signal.ts` — change `event` field from `event?: Event` to `event: Event` (always required)
+  - [x] 3.2 Update `dispatch_()` in `src/directive.ts` — change signature from `dispatch_(event?: Event)` to `dispatch_(event: Event)` and always pass `event` in the signal payload
+  - [x] 3.3 Update `init_()` in `src/directive.ts` — for `eventType === 'init'`, create a synthetic `CustomEvent('init', {bubbles: false, cancelable: false})`, dispatch it on `element_` via `element_.dispatchEvent()`, then call `dispatch_(syntheticEvent)` instead of `dispatch_()`
+  - [x] 3.4 Update `alwatrOn` in `src/method.ts` — change handler signature to `(payload: string, event: Event) => void` (remove optional) and forward `payload.event` as the second argument
 
-- [x] 4. Build and verify
-  - [x] 4.1 Run `bun run build` inside `pkg/nanolib/on/`
-  - [x] 4.2 Verify `dist/` output is generated correctly
+- [x] 4. Write README.md
+  - [x] 4.1 Document installation, attribute syntax format, `registerAlwatrOnDirective()` opt-in, `alwatrOn` API, and usage examples
+
+- [x] 5. Build and verify
+  - [x] 5.1 Run `bun run build` inside `pkg/nanolib/on/`
+  - [x] 5.2 Verify `dist/` output is generated correctly
+
+- [ ]\* 6. Write property-based tests
+  - [ ]\* 6.1 Create `src/directive.test.js` — test `syntaxRegex` parsing (valid/invalid inputs), payload resolution (`''`, `$value`, literal), `init` one-shot dispatch, listener cleanup symmetry — Props 1–6, 9
+  - [ ]\* 6.2 Create `src/method.test.js` — test `alwatrOn` action isolation, event forwarding, and unsubscribe behavior — Props 7–8, 10

--- a/pkg/nanolib/on/src/directive.ts
+++ b/pkg/nanolib/on/src/directive.ts
@@ -57,7 +57,11 @@ export class AlwatrActionDirective extends DirectiveBase {
     const eventType = this.match[1];
 
     if (eventType === 'init') {
-      this.dispatch_();
+      // Create a synthetic CustomEvent so event.target === element_ and event.type === 'init'.
+      // dispatchEvent must be called first so the browser sets event.target before we forward it.
+      const syntheticEvent = new CustomEvent('init', {bubbles: false, cancelable: false});
+      this.element_.dispatchEvent(syntheticEvent);
+      this.dispatch_(syntheticEvent);
       void this.destroy();
       return;
     }
@@ -72,11 +76,16 @@ export class AlwatrActionDirective extends DirectiveBase {
   /**
    * Resolves the action payload and dispatches the action signal.
    *
-   * - Calls `event.preventDefault()` when a DOM event is provided.
+   * - Calls `event.preventDefault()` to suppress default browser behaviour.
    * - Resolves `$value` to `element_.value` for input-like elements.
+   * - Always receives a valid `Event` — either a real DOM event or the synthetic
+   *   `CustomEvent('init')` created in `init_()`.
+   *
+   * Signature is compatible with `EventListener` so it can be passed directly
+   * to `addEventListener`.
    */
-  protected dispatch_(event?: Event): void {
-    event?.preventDefault();
+  protected dispatch_(event: Event): void {
+    event.preventDefault();
 
     const actionId = this.match![2];
     const actionPayloadRaw = this.match![3];
@@ -86,7 +95,7 @@ export class AlwatrActionDirective extends DirectiveBase {
       actionPayload = (this.element_ as {value: string}).value;
     }
 
-    eventSignal_.dispatch({actionId, actionPayload});
+    eventSignal_.dispatch({actionId, actionPayload, event});
   }
 }
 

--- a/pkg/nanolib/on/src/method.ts
+++ b/pkg/nanolib/on/src/method.ts
@@ -9,23 +9,25 @@ import type {SubscribeResult} from '@alwatr/signal';
  * method for cleanup.
  *
  * @param actionId - The action identifier to listen for (e.g. `'open-drawer'`).
- * @param handler  - Callback invoked with the resolved payload string.
+ * @param handler  - Callback invoked with the resolved payload string and the
+ *                   originating DOM event (always a valid `Event` — never `undefined`).
  * @returns A subscription result with an `unsubscribe` method.
  *
  * @example
  * ```ts
- * const sub = alwatrOn('open-drawer', (payload) => {
- *   openDrawer(payload); // payload === 'main'
+ * const sub = alwatrOn('open-drawer', (payload, event) => {
+ *   console.log('open drawer:', payload); // 'main'
+ *   console.log('triggered by:', event.type); // 'click'
  * });
  *
  * // Later, when cleanup is needed:
  * sub.unsubscribe();
  * ```
  */
-export function alwatrOn(actionId: string, handler: (payload: string) => void): SubscribeResult {
+export function alwatrOn(actionId: string, handler: (payload: string, event: Event) => void): SubscribeResult {
   return eventSignal_.subscribe((payload) => {
     if (payload.actionId === actionId) {
-      handler(payload.actionPayload);
+      handler(payload.actionPayload, payload.event);
     }
   });
 }

--- a/pkg/nanolib/on/src/signal.ts
+++ b/pkg/nanolib/on/src/signal.ts
@@ -3,6 +3,17 @@ import {createEventSignal} from '@alwatr/signal';
 export interface EventSignalPayload {
   actionId: string;
   actionPayload: string;
+  /**
+   * The DOM event that triggered this dispatch.
+   *
+   * For standard DOM event types (e.g. 'click', 'input'), this is the original browser Event.
+   * For the special 'init' event type, this is a synthetic CustomEvent dispatched on the element
+   * via `element_.dispatchEvent(new CustomEvent('init', {bubbles: false, cancelable: false}))`,
+   * so `event.target === element_` and `event.type === 'init'`.
+   *
+   * Always present — never undefined.
+   */
+  event: Event;
 }
 
 /**


### PR DESCRIPTION
## Description

Enhance the `alwatr-on` directive to ensure that the originating DOM event is always passed to handlers. This change improves event handling by providing access to the event object, allowing for more robust event management in applications. The update includes modifications to the `EventSignalPayload` interface and the `alwatrOn` function signature to require the event parameter. Additionally, a synthetic `CustomEvent` is created for the 'init' event type to maintain consistency in event handling.

