### PR TITLE
Add global page-ready subscription functionality

### DIFF
--- a/.kiro/steering/patterns.md
+++ b/.kiro/steering/patterns.md
@@ -229,8 +229,8 @@ onAction('open_drawer', (panel) => {
 });
 
 // Typed payload
-onAction<{productId: number; qty: number}>('add_to_cart', (item) => {
-  cartService.add(item!.productId, item!.qty);
+onAction('add_to_cart', (item) => {
+  cartService.add(item.productId, item.qty);
 });
 
 // Cleanup when component is destroyed

--- a/.kiro/steering/patterns.md
+++ b/.kiro/steering/patterns.md
@@ -168,13 +168,13 @@ Uses **global event delegation**: one capture-phase listener on `document.body` 
 
 ```
 UI (HTML attributes)
-  │  on-action="click->add-to-cart:42"
+  │  on-action="click->add_to_cart:42"
   ▼
 Action Layer (@alwatr/action)
   │  document.body capture listener → closest('[on-action]') → dispatchAction
   ▼
 Business Logic
-  │  onAction('add-to-cart', id => cartService.add(id))
+  │  onAction('add_to_cart', id => cartService.add(id))
   ▼
 State Layer (@alwatr/signal)
   │  cartSignal.dispatch(newState)
@@ -209,9 +209,9 @@ Extend `ActionRecord` via declaration merging in each feature package:
 // src/action-record.ts
 declare module '@alwatr/action' {
   interface ActionRecord {
-    'open_drawer': string;
-    'add-to-cart': {productId: number; qty: number};
-    'logout': void;
+    open_drawer: string;
+    add_to_cart: {productId: number; qty: number};
+    logout: void;
   }
 }
 ```
@@ -229,7 +229,7 @@ onAction('open_drawer', (panel) => {
 });
 
 // Typed payload
-onAction<{productId: number; qty: number}>('add-to-cart', (item) => {
+onAction<{productId: number; qty: number}>('add_to_cart', (item) => {
   cartService.add(item!.productId, item!.qty);
 });
 
@@ -245,7 +245,7 @@ import {dispatchAction} from '@alwatr/action';
 
 // After an async operation completes
 await uploadFile(file);
-dispatchAction('upload-complete', fileId);
+dispatchAction('upload_complete', fileId);
 
 // From a service layer
 dispatchAction('navigate', '/dashboard');
@@ -262,11 +262,11 @@ on-action="eventType[.modifier…]->actionId[:payload]"
 <button on-action="click->open_drawer:settings">Settings</button>
 
 <!-- Dynamic payload from input value -->
-<input on-action="input->search-query:$value" />
+<input on-action="input->search_query:$value" />
 
 <!-- Form data payload with validation -->
 <form
-  on-action="submit.prevent.validate->submit-form:$formdata"
+  on-action="submit.prevent.validate->submit_form:$formdata"
   novalidate
 >
   …
@@ -308,7 +308,7 @@ registerPayloadResolver('$data-id', (_event, element) => {
 
 ```html
 <button
-  on-action="click.not-disabled->select-item:$data-id"
+  on-action="click.not-disabled->select_item:$data-id"
   data-id="42"
 >
   Select

--- a/.kiro/steering/patterns.md
+++ b/.kiro/steering/patterns.md
@@ -185,13 +185,20 @@ UI (re-render)
 ### Bootstrap
 
 ```ts
-import {setupActionDelegation, dispatchPageId} from '@alwatr/action';
+import {setupActionDelegation} from '@alwatr/action';
+import {onPageReady, subscribePageReady, dispatchPageReady} from '@alwatr/page-ready';
 
 // One call — covers the entire page including future dynamic content.
 setupActionDelegation();
 
-// Optional: read page-id attribute and dispatch 'page-ready'
-dispatchPageId();
+// Subscribe to a specific page before dispatching.
+onPageReady('home', () => initHomePage());
+
+// Or subscribe to ALL pages — handler receives the page ID.
+subscribePageReady((pageId) => analytics.trackPageView(pageId));
+
+// Read [page-id] attribute via querySelector and notify subscribers.
+dispatchPageReady();
 ```
 
 ### Registering typed actions
@@ -202,7 +209,7 @@ Extend `ActionRecord` via declaration merging in each feature package:
 // src/action-record.ts
 declare module '@alwatr/action' {
   interface ActionRecord {
-    'open-drawer': string;
+    'open_drawer': string;
     'add-to-cart': {productId: number; qty: number};
     'logout': void;
   }
@@ -217,7 +224,7 @@ Passing an undeclared action name to `onAction` or `dispatchAction` is a **compi
 import {onAction} from '@alwatr/action';
 
 // String payload (default)
-onAction('open-drawer', (panel) => {
+onAction('open_drawer', (panel) => {
   drawerSignal.dispatch({open: true, panel});
 });
 
@@ -252,7 +259,7 @@ on-action="eventType[.modifier…]->actionId[:payload]"
 
 ```html
 <!-- Literal payload -->
-<button on-action="click->open-drawer:settings">Settings</button>
+<button on-action="click->open_drawer:settings">Settings</button>
 
 <!-- Dynamic payload from input value -->
 <input on-action="input->search-query:$value" />

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -62,6 +62,7 @@ A TypeScript/ESM monorepo of small, focused libraries for building robust JavaSc
 | `@alwatr/local-storage`   | Versioned JSON in `localStorage`. `createLocalStorageProvider({name, schemaVersion})`. Auto-migrates on version bump.                                                                                                                                                                                                                     |
 | `@alwatr/session-storage` | Same as `local-storage` but scoped to `sessionStorage`.                                                                                                                                                                                                                                                                                   |
 | `@alwatr/render-state`    | Render state management utility.                                                                                                                                                                                                                                                                                                          |
+| `@alwatr/page-ready`      | MPA page identity signal. `onPageReady(pageId, handler)` — subscribe to a specific page. `subscribePageReady(handler)` — subscribe to all pages (handler receives the page ID). `dispatchPageReady()` — reads `[page-id]` attribute via `querySelector` and notifies subscribers. O(1) dispatch via `ChannelSignal`.                      |
 
 ### HTTP / Network
 

--- a/pkg/nanolib/action/README.md
+++ b/pkg/nanolib/action/README.md
@@ -34,12 +34,12 @@ User clicks a button
 document.body capture listener  (1 listener per event type)
         │
         └─ closest('[on-action^=click]') → finds element
-           parse attribute → 'click->add-to-cart:42'
+           parse attribute → 'click->add_to_cart:42'
            run modifiers   → none
            resolve payload → '42'
-           internalChannel_.dispatch('add-to-cart', '42')
+           internalChannel_.dispatch('add_to_cart', '42')
                 │
-                └─ Map.get('add-to-cart') → O(1) → invoke only matching handlers
+                └─ Map.get('add_to_cart') → O(1) → invoke only matching handlers
 ```
 
 ### Complexity
@@ -77,10 +77,10 @@ Extend `ActionRecord` via declaration merging. This gives you full type safety a
 // src/action-record.ts
 declare module '@alwatr/action' {
   interface ActionRecord {
-    'open-drawer': string;
-    'search-query': string;
-    'add-to-cart': {productId: number; qty: number};
-    'logout': void;
+    open_drawer: string;
+    search_query: string;
+    add_to_cart: {productId: number; qty: number};
+    logout: void;
   }
 }
 ```
@@ -94,8 +94,8 @@ import './action-record.js'; // ensure the declaration is loaded
 setupActionDelegation();
 
 // Payload types are inferred from ActionRecord — no generics needed.
-onAction('open-drawer', (panel) => openDrawer(panel)); // panel: string
-onAction('add-to-cart', (item) => {
+onAction('open_drawer', (panel) => openDrawer(panel)); // panel: string
+onAction('add_to_cart', (item) => {
   cartService.add(item.productId, item.qty); // fully typed
 });
 ```
@@ -103,19 +103,19 @@ onAction('add-to-cart', (item) => {
 ### 3. Add attributes to HTML
 
 ```html
-<!-- Dispatches 'open-drawer' with payload 'main' on click -->
-<button on-action="click->open-drawer:main">Open Drawer</button>
+<!-- Dispatches 'open_drawer' with payload 'main' on click -->
+<button on-action="click->open_drawer:main">Open Drawer</button>
 
-<!-- Dispatches 'search-query' with the input's live value -->
+<!-- Dispatches 'search_query' with the input's live value -->
 <input
   type="search"
-  on-action="input->search-query:$value"
+  on-action="input->search_query:$value"
   placeholder="Search…"
 />
 
 <!-- Prevents default, validates, then dispatches all field values -->
 <form
-  on-action="submit.prevent.validate->submit-form:$formdata"
+  on-action="submit.prevent.validate->submit_form:$formdata"
   novalidate
 >
   <input
@@ -126,7 +126,7 @@ onAction('add-to-cart', (item) => {
 </form>
 
 <!-- Fires only once — attribute is removed after first click -->
-<button on-action="click.once->welcome-dismissed">Got it</button>
+<button on-action="click.once->welcome_dismissed">Got it</button>
 ```
 
 ### 4. Programmatic dispatch
@@ -135,7 +135,7 @@ onAction('add-to-cart', (item) => {
 import {dispatchAction} from '@alwatr/action';
 
 await uploadFile(file);
-dispatchAction('upload-complete', fileId);
+dispatchAction('upload_complete', fileId);
 
 dispatchAction('navigate', '/dashboard');
 ```
@@ -152,7 +152,7 @@ on-action="eventType[.modifier…]->actionId[:payload]"
 | ----------- | --------------------------------------------------------- | ----------------------------- |
 | `eventType` | Any standard DOM event name                               | `click`, `input`, `submit`    |
 | `modifier`  | Optional dot-chained tokens processed before dispatch     | `.prevent`, `.validate`       |
-| `actionId`  | Identifier your handler subscribes to                     | `open-drawer`, `search-query` |
+| `actionId`  | Identifier your handler subscribes to                     | `open_drawer`, `search_query` |
 | `:payload`  | Optional literal string, or a `$`-prefixed resolver token | `:main`, `:$value`            |
 
 ### Built-in modifiers
@@ -181,8 +181,8 @@ The global action type registry. Extend via declaration merging to register type
 ```ts
 declare module '@alwatr/action' {
   interface ActionRecord {
-    'open-drawer': string;
-    'logout': void;
+    open_drawer: string;
+    logout: void;
   }
 }
 ```
@@ -229,7 +229,7 @@ function onAction<K extends keyof ActionRecord>(
 ```
 
 ```ts
-const sub = onAction('open-drawer', (panel) => openDrawer(panel));
+const sub = onAction('open_drawer', (panel) => openDrawer(panel));
 sub.unsubscribe(); // prevent memory leaks
 ```
 
@@ -241,7 +241,7 @@ Dispatches a named action. Payload type is enforced by `ActionRecord`.
 
 ```ts
 // With payload
-dispatchAction('open-drawer', 'settings');
+dispatchAction('open_drawer', 'settings');
 
 // Void payload — no second argument
 dispatchAction('logout');
@@ -266,7 +266,7 @@ registerModifier('not-disabled', (_event, element) => {
 
 ```html
 <button
-  on-action="click.not-disabled->select-item:$data-id"
+  on-action="click.not-disabled->select_item:$data-id"
   data-id="42"
 >
   Select
@@ -296,10 +296,10 @@ registerPayloadResolver('$data-id', (_event, element) => {
 ```html
 <input
   type="checkbox"
-  on-action="change->toggle-feature:$checked"
+  on-action="change->toggle_feature:$checked"
 />
 <li
-  on-action="click->select-item:$data-id"
+  on-action="click->select_item:$data-id"
   data-id="42"
 >
   Item
@@ -313,7 +313,7 @@ registerPayloadResolver('$data-id', (_event, element) => {
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                        UI Layer                         │
-│  <button on-action="click->add-to-cart:42">Add</button> │
+│  <button on-action="click->add_to_cart:42">Add</button> │
 └────────────────────────┬────────────────────────────────┘
                          │ DOM event bubbles to body
                          ▼
@@ -321,13 +321,13 @@ registerPayloadResolver('$data-id', (_event, element) => {
 │              Action Layer (@alwatr/action)               │
 │  document.body capture listener (1 per event type)      │
 │  → closest('[on-action]') → parse → modifiers           │
-│  → internalChannel_.dispatch('add-to-cart', '42') [O(1)]│
+│  → internalChannel_.dispatch('add_to_cart', '42') [O(1)]│
 └────────────────────────┬────────────────────────────────┘
                          │ O(1) routing via ChannelSignal
                          ▼
 ┌─────────────────────────────────────────────────────────┐
 │                   Business Logic Layer                  │
-│  onAction('add-to-cart', (id) => cartService.add(id))   │
+│  onAction('add_to_cart', (id) => cartService.add(id))   │
 └────────────────────────┬────────────────────────────────┘
                          │ state update
                          ▼

--- a/pkg/nanolib/page-ready/README.md
+++ b/pkg/nanolib/page-ready/README.md
@@ -130,7 +130,7 @@ Finds the first `[page-id]` element anywhere in the document and notifies all ma
 function dispatchPageReady(): void;
 ```
 
-Call once at application bootstrap. Logs an accident if no `[page-id]` element is found or the attribute value is empty.
+Call once at application bootstrap. Logs an accident if no `[page-id]` element is found in the document. An empty attribute value (`page-id=""`) is treated as a valid identifier and dispatched normally.
 
 The lookup uses `document.querySelector('[page-id]')`, so the attribute can be placed on any element (`<body>`, `<main>`, `<div>`, etc.).
 

--- a/pkg/nanolib/page-ready/README.md
+++ b/pkg/nanolib/page-ready/README.md
@@ -2,13 +2,13 @@
 
 **Lightweight page identity signal for multi page applications routing.**
 
-## Reads the `page-id` HTML attribute from the document and notifies subscribers using a dedicated O(1) channel signal. Designed for SSG/SSR setups where each generated page has a different `page-id` baked into the HTML
+Reads the `page-id` HTML attribute from the document and notifies subscribers using a dedicated O(1) channel signal. Designed for SSG/SSR setups where each generated page has a different `page-id` baked into the HTML.
 
 ---
 
 ## Why `@alwatr/page-ready`?
 
-In SSG/SSR apps, the server renders a different HTML page for each route. Each page has a `page-id` attribute on `<body>`. Instead of a full client-side router, you just need to know _which page is currently loaded_ so you can run page-specific initialization logic.
+In SSG/SSR apps, the server renders a different HTML page for each route. Each page has a `page-id` attribute somewhere in the document. Instead of a full client-side router, you just need to know _which page is currently loaded_ so you can run page-specific initialization logic.
 
 `@alwatr/page-ready` solves exactly this — nothing more.
 
@@ -29,7 +29,7 @@ npm i @alwatr/page-ready
 ### 1. Add `page-id` to your HTML
 
 ```html
-<!-- Each SSG-generated page has a unique page-id -->
+<!-- Each SSG-generated page has a unique page-id — can be on any element -->
 <body page-id="home">
   …
 </body>
@@ -38,15 +38,22 @@ npm i @alwatr/page-ready
 ### 2. Subscribe and dispatch
 
 ```ts
-import {onPageReady, dispatchPageReady} from '@alwatr/page-ready';
+import {onPageReady, subscribePageReady, dispatchPageReady} from '@alwatr/page-ready';
 
 // Optionally constrain valid page IDs with a type alias
 type PageId = 'home' | 'about' | 'product-detail';
 
+// Subscribe to a specific page
 onPageReady<PageId>('home', () => initHomePage());
 onPageReady<PageId>('about', () => initAboutPage());
 
-// Call once at bootstrap — finds [page-id] in the document and notifies the matching handler
+// Or subscribe to ALL pages and receive the page ID in the handler
+subscribePageReady<PageId>((pageId) => {
+  console.log('Page ready:', pageId);
+  analytics.trackPageView(pageId);
+});
+
+// Call once at bootstrap — finds [page-id] anywhere in the document and notifies subscribers
 dispatchPageReady();
 ```
 
@@ -61,11 +68,13 @@ dispatchPageReady()
        │
        └─ pageReadyChannel_.dispatch('home')
             │
-            └─ Map.get('home') → O(1) → invoke only 'home' handlers
+            ├─ Map.get('home') → O(1) → invoke only 'home' handlers  (onPageReady)
+            └─ global subscribers → invoked for every page ID         (subscribePageReady)
 ```
 
-- `dispatchPageReady` finds the element automatically — no argument needed.
-- `ChannelSignal` routes in O(1): only handlers for the current page ID are invoked.
+- `dispatchPageReady` scans the entire document for the first `[page-id]` element — no argument needed.
+- `ChannelSignal` routes in O(1): `onPageReady` handlers for non-matching page IDs are never invoked.
+- `subscribePageReady` handlers receive the dispatched page ID and are called on every dispatch.
 
 ---
 
@@ -73,10 +82,10 @@ dispatchPageReady()
 
 ### `onPageReady(pageId, handler)`
 
-Subscribes to a specific page becoming ready.
+Subscribes to a **specific** page becoming ready. The handler is only invoked when the dispatched page ID matches `pageId`.
 
 ```ts
-function onPageReady<T extends string>(pageId: T, handler: () => void): SubscribeResult;
+function onPageReady<T extends string>(pageId: T, handler: () => Awaitable<void>): SubscribeResult;
 ```
 
 Pass a string literal union as the generic to constrain valid page IDs:
@@ -90,15 +99,51 @@ sub.unsubscribe(); // stop listening when no longer needed
 
 ---
 
+### `subscribePageReady(handler)`
+
+Subscribes to **all** page-ready events. The handler is invoked on every `dispatchPageReady()` call, regardless of which page ID is dispatched. The current page ID is passed as the first argument.
+
+```ts
+function subscribePageReady<T extends string>(handler: (pageId: T) => Awaitable<void>): SubscribeResult;
+```
+
+Useful for cross-cutting concerns like analytics, logging, or layout transitions that need to react to every page change:
+
+```ts
+type PageId = 'home' | 'about' | 'product-detail';
+
+const sub = subscribePageReady<PageId>((pageId) => {
+  analytics.trackPageView(pageId);
+  updateActiveNavLink(pageId);
+});
+
+sub.unsubscribe(); // stop listening when no longer needed
+```
+
+---
+
 ### `dispatchPageReady()`
 
-Finds the first `[page-id]` element in the document and notifies matching subscribers.
+Finds the first `[page-id]` element anywhere in the document and notifies all matching subscribers.
 
 ```ts
 function dispatchPageReady(): void;
 ```
 
-Call once at application bootstrap. Logs an accident if no `[page-id]` element is found.
+Call once at application bootstrap. Logs an accident if no `[page-id]` element is found or the attribute value is empty.
+
+The lookup uses `document.querySelector('[page-id]')`, so the attribute can be placed on any element (`<body>`, `<main>`, `<div>`, etc.).
+
+---
+
+## Choosing Between `onPageReady` and `subscribePageReady`
+
+| Use case                                    | API                  |
+| ------------------------------------------- | -------------------- |
+| Initialize logic for one specific page      | `onPageReady`        |
+| React to every page change (analytics, nav) | `subscribePageReady` |
+| Multiple pages, each with their own init    | `onPageReady` × N    |
+| Single handler that branches on the page ID | `subscribePageReady` |
 
 ---
 

--- a/pkg/nanolib/page-ready/src/main.ts
+++ b/pkg/nanolib/page-ready/src/main.ts
@@ -1,29 +1,34 @@
 /**
  * @alwatr/page-ready — Lightweight page identity signal for MPA routing.
  *
- * Reads the `page-id` attribute from `document.body` and dispatches a named
- * signal so any part of the application can react to the current page without
- * coupling to a full router.
+ * Reads the `page-id` attribute from the first matching element in the document
+ * and dispatches a named signal so any part of the application can react to the
+ * current page without coupling to a full router.
  *
  * ## Usage
  *
  * ```html
+ * <!-- page-id can be placed on any element, not just <body> -->
  * <body page-id="home">…</body>
  * ```
  *
  * ```ts
- * import {onPageReady, dispatchPageReady} from '@alwatr/page-ready';
+ * import {onPageReady, subscribePageReady, dispatchPageReady} from '@alwatr/page-ready';
  *
- * // Subscribe before dispatching so the handler is registered in time.
+ * // Subscribe to a specific page before dispatching.
  * onPageReady('home', () => initHomePage());
  *
- * // Call once at bootstrap — reads document.body[page-id] and notifies subscribers.
+ * // Or subscribe to ALL pages — handler receives the page ID.
+ * subscribePageReady((pageId) => analytics.trackPageView(pageId));
+ *
+ * // Call once at bootstrap — finds [page-id] anywhere in the document and notifies subscribers.
  * dispatchPageReady();
  * ```
  *
  * ## Public API
  *
- * - `onPageReady(pageId, handler)` — subscribe to a specific page becoming ready
- * - `dispatchPageReady(element?)` — read `page-id` attribute and notify subscribers
+ * - `onPageReady(pageId, handler)` — subscribe to a **specific** page becoming ready
+ * - `subscribePageReady(handler)` — subscribe to **all** page-ready events; handler receives the page ID
+ * - `dispatchPageReady()` — find `[page-id]` via `querySelector` and notify subscribers
  */
 export * from './page-ready.js';

--- a/pkg/nanolib/page-ready/src/page-ready.ts
+++ b/pkg/nanolib/page-ready/src/page-ready.ts
@@ -76,6 +76,45 @@ export function onPageReady<T extends string>(pageId: T, handler: () => Awaitabl
 }
 
 /**
+ * Subscribes to **all** page-ready events, regardless of which page ID is dispatched.
+ *
+ * Unlike `onPageReady` — which targets a single page ID — this handler is invoked
+ * every time `dispatchPageReady()` fires, and receives the dispatched page ID as
+ * its first argument.
+ *
+ * Useful for cross-cutting concerns that must react to every page change:
+ * analytics tracking, active nav-link updates, layout transitions, etc.
+ *
+ * Pass a string literal union as the generic parameter to get type-safe page IDs:
+ *
+ * ```ts
+ * type PageId = 'home' | 'about' | 'product-detail';
+ *
+ * subscribePageReady<PageId>((pageId) => {
+ *   analytics.trackPageView(pageId);
+ *   updateActiveNavLink(pageId);
+ * });
+ * ```
+ *
+ * @param handler - Called with the dispatched page ID on every `dispatchPageReady()` call.
+ * @returns A `SubscribeResult` with an `unsubscribe()` method for cleanup.
+ *
+ * @example
+ * ```ts
+ * import {subscribePageReady} from '@alwatr/page-ready';
+ *
+ * const sub = subscribePageReady((pageId) => console.log('Page ready:', pageId));
+ * sub.unsubscribe(); // stop listening when no longer needed
+ * ```
+ */
+export function subscribePageReady<T extends string>(handler: (pageId: T) => Awaitable<void>): SubscribeResult {
+  logger.logMethodArgs?.('subscribePageReady', {handler: handler.name});
+  return pageReadyChannel_.subscribe((message) => {
+    handler(message.name as T);
+  });
+}
+
+/**
  * Reads the `page-id` attribute from the first matching element in the document
  * and notifies all `onPageReady` subscribers registered for that page identifier.
  *
@@ -101,10 +140,11 @@ export function dispatchPageReady(): void {
 
   const pageId = document.querySelector('[page-id]')?.getAttribute('page-id')?.trim();
 
-  if (!pageId) {
+  if (pageId == null) {
     logger.accident('dispatchPageReady', 'page_id_not_found');
     return;
   }
 
+  // accept empty pageId as a valid identifier
   pageReadyChannel_.dispatch(pageId);
 }

--- a/pkg/nanolib/page-ready/src/page-ready.ts
+++ b/pkg/nanolib/page-ready/src/page-ready.ts
@@ -108,7 +108,7 @@ export function onPageReady<T extends string>(pageId: T, handler: () => Awaitabl
  * ```
  */
 export function subscribePageReady<T extends string>(handler: (pageId: T) => Awaitable<void>): SubscribeResult {
-  logger.logMethodArgs?.('subscribePageReady', {handler: handler.name});
+  logger.logMethod?.('subscribePageReady');
   return pageReadyChannel_.subscribe((message) => {
     handler(message.name as T);
   });
@@ -121,8 +121,9 @@ export function subscribePageReady<T extends string>(handler: (pageId: T) => Awa
  * Finds the element via `document.querySelector('[page-id]')` — no argument
  * needed. Call once at application bootstrap after the DOM is ready.
  *
- * If no element with `page-id` is found, or the attribute value is empty,
- * an accident is logged and nothing is dispatched.
+ * If no element with `page-id` is found in the document, an accident is logged
+ * and nothing is dispatched. An empty attribute value (`page-id=""`) is treated
+ * as a valid identifier and will be dispatched normally.
  *
  * @example
  * ```html
@@ -145,6 +146,6 @@ export function dispatchPageReady(): void {
     return;
   }
 
-  // accept empty pageId as a valid identifier
+  // An empty string is a valid page identifier — dispatch as-is.
   pageReadyChannel_.dispatch(pageId);
 }


### PR DESCRIPTION
## Description

Introduce a `subscribePageReady` function to allow global subscription to page-ready events, enhancing cross-cutting capabilities such as analytics tracking and layout transitions. Update documentation to clarify usage and provide examples for both specific and global subscriptions. Improve the handling of the `page-id` attribute to accept it from any element in the document. Standardize action naming conventions and update related documentation for consistency.

