### PR TITLE
Refactor action attribute syntax to event-type-specific naming

### DIFF
--- a/pkg/nanolib/action/README.md
+++ b/pkg/nanolib/action/README.md
@@ -2,7 +2,7 @@
 
 **Declarative DOM action-dispatch — the Action layer for Unidirectional Data Flow.**
 
-`@alwatr/action` bridges HTML `on-action` attributes to typed signal handlers using **global event delegation**. One listener on `document.body` covers every element on the page — including elements added dynamically after bootstrap — with O(1) initialization cost regardless of how many elements exist.
+`@alwatr/action` bridges HTML `on-<eventType>` attributes to typed signal handlers using **global event delegation**. One listener on `document.body` covers every element on the page — including elements added dynamically after bootstrap — with O(1) initialization cost regardless of how many elements exist.
 
 ---
 
@@ -25,7 +25,7 @@ The action bus is powered by a [`ChannelSignal`](../signal/README.md) from `@alw
 
 ### Global Event Delegation
 
-A single capture-phase listener on `document.body` handles all `on-action` elements. When an event fires, the handler walks up from `event.target` using `closest('[on-action]')`, parses the attribute, runs modifiers, resolves the payload, and dispatches the action.
+A single capture-phase listener on `document.body` handles all `on-<eventType>` elements. When an event fires, the handler walks up from `event.target` using `closest('[on-click]')` (or the matching attribute), parses the attribute value, runs modifiers, resolves the payload, and dispatches the action.
 
 ```
 User clicks a button
@@ -33,8 +33,8 @@ User clicks a button
         ▼
 document.body capture listener  (1 listener per event type)
         │
-        └─ closest('[on-action^=click]') → finds element
-           parse attribute → 'click->add_to_cart:42'
+        └─ closest('[on-click]') → finds element
+           parse attribute → 'add_to_cart:42'
            run modifiers   → none
            resolve payload → '42'
            internalChannel_.dispatch('add_to_cart', '42')
@@ -53,7 +53,7 @@ document.body capture listener  (1 listener per event type)
 
 ### `once` modifier
 
-In delegation mode, `once` is implemented by removing the `on-action` attribute from the element after the first fire. This is simpler than a `WeakSet` cache and naturally handles element reuse — if the element is re-rendered with the attribute, it fires again.
+In delegation mode, `once` is implemented by removing the `on-<eventType>` attribute from the element after the first fire. This is simpler than a `WeakSet` cache and naturally handles element reuse — if the element is re-rendered with the attribute, it fires again.
 
 ---
 
@@ -103,19 +103,22 @@ onAction('add_to_cart', (item) => {
 ### 3. Add attributes to HTML
 
 ```html
+<!-- Dispatches 'close_drawer' on click — no payload -->
+<button on-click="close_drawer">Close</button>
+
 <!-- Dispatches 'open_drawer' with payload 'main' on click -->
-<button on-action="click->open_drawer:main">Open Drawer</button>
+<button on-click="open_drawer:main">Open Drawer</button>
 
 <!-- Dispatches 'search_query' with the input's live value -->
 <input
   type="search"
-  on-action="input->search_query:$value"
+  on-input="search_query:$value"
   placeholder="Search…"
 />
 
 <!-- Prevents default, validates, then dispatches all field values -->
 <form
-  on-action="submit.prevent.validate->submit_form:$formdata"
+  on-submit="submit_form:$formdata; prevent,validate"
   novalidate
 >
   <input
@@ -126,7 +129,7 @@ onAction('add_to_cart', (item) => {
 </form>
 
 <!-- Fires only once — attribute is removed after first click -->
-<button on-action="click.once->welcome_dismissed">Got it</button>
+<button on-click="welcome_dismissed; once">Got it</button>
 ```
 
 ### 4. Programmatic dispatch
@@ -145,23 +148,23 @@ dispatchAction('navigate', '/dashboard');
 ## Attribute Syntax
 
 ```
-on-action="eventType[.modifier…]->actionId[:payload]"
+on-<eventType>="actionId[:payload][; modifier1,modifier2,…]"
 ```
 
-| Segment     | Description                                               | Example                       |
-| ----------- | --------------------------------------------------------- | ----------------------------- |
-| `eventType` | Any standard DOM event name                               | `click`, `input`, `submit`    |
-| `modifier`  | Optional dot-chained tokens processed before dispatch     | `.prevent`, `.validate`       |
-| `actionId`  | Identifier your handler subscribes to                     | `open_drawer`, `search_query` |
-| `:payload`  | Optional literal string, or a `$`-prefixed resolver token | `:main`, `:$value`            |
+| Segment       | Description                                                 | Example                       |
+| ------------- | ----------------------------------------------------------- | ----------------------------- |
+| `eventType`   | Any standard DOM event name — encoded in the attribute name | `on-click`, `on-submit`       |
+| `actionId`    | Identifier your handler subscribes to                       | `open_drawer`, `search_query` |
+| `:payload`    | Optional literal string, or a `$`-prefixed resolver token   | `:main`, `:$value`            |
+| `; modifiers` | Optional comma-separated modifier list after a semicolon    | `; prevent,validate`          |
 
 ### Built-in modifiers
 
-| Modifier    | Behavior                                                                         |
-| ----------- | -------------------------------------------------------------------------------- |
-| `.prevent`  | Calls `event.preventDefault()`                                                   |
-| `.once`     | Removes the `on-action` attribute after first fire — action dispatches only once |
-| `.validate` | Cancels dispatch if the nearest `<form>` fails `checkValidity()`                 |
+| Modifier   | Behavior                                                                              |
+| ---------- | ------------------------------------------------------------------------------------- |
+| `prevent`  | Calls `event.preventDefault()`                                                        |
+| `once`     | Removes the `on-<eventType>` attribute after first fire — action dispatches only once |
+| `validate` | Cancels dispatch if the nearest `<form>` fails `checkValidity()`                      |
 
 ### Built-in payload resolvers
 
@@ -258,15 +261,14 @@ Handler signature: `(event: Event, element: HTMLElement) => boolean`
 ```ts
 import {registerModifier} from '@alwatr/action';
 
-// Arrow function — no `this` binding needed
-registerModifier('not-disabled', (_event, element) => {
+registerModifier('not_disabled', (_event, element) => {
   return !(element as HTMLButtonElement).disabled;
 });
 ```
 
 ```html
 <button
-  on-action="click.not-disabled->select_item:$data-id"
+  on-click="select_item:$data_id; not_disabled"
   data-id="42"
 >
   Select
@@ -288,7 +290,7 @@ registerPayloadResolver('$checked', (_event, element) => {
   return (element as HTMLInputElement).checked;
 });
 
-registerPayloadResolver('$data-id', (_event, element) => {
+registerPayloadResolver('$data_id', (_event, element) => {
   return (element as HTMLElement).dataset.id ?? null;
 });
 ```
@@ -296,10 +298,10 @@ registerPayloadResolver('$data-id', (_event, element) => {
 ```html
 <input
   type="checkbox"
-  on-action="change->toggle_feature:$checked"
+  on-change="toggle_feature:$checked"
 />
 <li
-  on-action="click->select_item:$data-id"
+  on-click="select_item:$data_id"
   data-id="42"
 >
   Item
@@ -311,33 +313,33 @@ registerPayloadResolver('$data-id', (_event, element) => {
 ## Unidirectional Data Flow
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                        UI Layer                         │
-│  <button on-action="click->add_to_cart:42">Add</button> │
-└────────────────────────┬────────────────────────────────┘
-                         │ DOM event bubbles to body
-                         ▼
-┌─────────────────────────────────────────────────────────┐
-│              Action Layer (@alwatr/action)               │
-│  document.body capture listener (1 per event type)      │
-│  → closest('[on-action]') → parse → modifiers           │
-│  → internalChannel_.dispatch('add_to_cart', '42') [O(1)]│
-└────────────────────────┬────────────────────────────────┘
-                         │ O(1) routing via ChannelSignal
-                         ▼
-┌─────────────────────────────────────────────────────────┐
-│                   Business Logic Layer                  │
-│  onAction('add_to_cart', (id) => cartService.add(id))   │
-└────────────────────────┬────────────────────────────────┘
-                         │ state update
-                         ▼
-┌─────────────────────────────────────────────────────────┐
-│                    State Layer (@alwatr/signal)          │
-│  cartSignal.set(newCartState)                           │
-└────────────────────────┬────────────────────────────────┘
-                         │ state flows down to UI
-                         ▼
-                      UI re-renders
+┌──────────────────────────────────────────────────────────┐
+│                         UI Layer                         │
+│  <button on-click="add_to_cart:42">Add</button>          │
+└─────────────────────────┬────────────────────────────────┘
+                          │ DOM event bubbles to body
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│               Action Layer (@alwatr/action)              │
+│  document.body capture listener (1 per event type)       │
+│  → closest('[on-click]') → parse → modifiers             │
+│  → internalChannel_.dispatch('add_to_cart', '42') [O(1)] │
+└─────────────────────────┬────────────────────────────────┘
+                          │ O(1) routing via ChannelSignal
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│                    Business Logic Layer                  │
+│  onAction('add_to_cart', (id) => cartService.add(id))    │
+└─────────────────────────┬────────────────────────────────┘
+                          │ state update
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│                 State Layer (@alwatr/signal)              │
+│  cartSignal.set(newCartState)                            │
+└─────────────────────────┬────────────────────────────────┘
+                          │ state flows down to UI
+                          ▼
+                       UI re-renders
 ```
 
 ---
@@ -353,6 +355,36 @@ concern, not a user-interaction action.
 
 ## Migration from Previous Versions
 
+### Attribute syntax changed
+
+The event type is now encoded in the **attribute name** instead of the value, and modifiers are listed after a semicolon instead of dot-chained before the arrow.
+
+**Before:**
+
+```html
+<button on-action="click->open_drawer:main">Open</button>
+<form
+  on-action="submit.prevent.validate->submit_form:$formdata"
+  novalidate
+>
+  …
+</form>
+<button on-action="click.once->welcome_dismissed">Got it</button>
+```
+
+**After:**
+
+```html
+<button on-click="open_drawer:main">Open</button>
+<form
+  on-submit="submit_form:$formdata; prevent,validate"
+  novalidate
+>
+  …
+</form>
+<button on-click="welcome_dismissed; once">Got it</button>
+```
+
 ### `ActionContext` removed
 
 The `this` context in modifier and resolver handlers changed to explicit parameters:
@@ -360,7 +392,7 @@ The `this` context in modifier and resolver handlers changed to explicit paramet
 **Before:**
 
 ```ts
-registerModifier('not-disabled', function () {
+registerModifier('not_disabled', function () {
   return !(this.element as HTMLButtonElement).disabled;
 });
 ```
@@ -368,15 +400,10 @@ registerModifier('not-disabled', function () {
 **After:**
 
 ```ts
-registerModifier('not-disabled', (_event, element) => {
+registerModifier('not_disabled', (_event, element) => {
   return !(element as HTMLButtonElement).disabled;
 });
 ```
-
-### `once` behavior changed
-
-Previously tracked via `WeakSet`. Now removes the `on-action` attribute after first fire.
-Behavior is equivalent for typical use cases.
 
 ### `page-ready` moved to `@alwatr/page-ready`
 

--- a/pkg/nanolib/action/src/action-record.ts
+++ b/pkg/nanolib/action/src/action-record.ts
@@ -13,8 +13,8 @@
  * // In your package: src/action-record.ts
  * declare module '@alwatr/action' {
  *   interface ActionRecord {
- *     'open-drawer': string;
- *     'add-to-cart': {productId: number; qty: number};
+ *     'open_drawer': string;
+ *     'add_to_cart': {productId: number; qty: number};
  *     'logout': void;
  *   }
  * }
@@ -43,8 +43,8 @@
  * // pkg/my-feature/src/action-record.ts
  * declare module '@alwatr/action' {
  *   interface ActionRecord {
- *     'open-drawer': string;
- *     'add-to-cart': {productId: number; qty: number};
+ *     'open_drawer': string;
+ *     'add_to_cart': {productId: number; qty: number};
  *     'logout': void;
  *   }
  * }

--- a/pkg/nanolib/action/src/delegate.ts
+++ b/pkg/nanolib/action/src/delegate.ts
@@ -10,12 +10,12 @@
  * time — O(N) initialization cost, O(N) memory for listener references, and
  * zero support for elements added after bootstrap.
  *
- * This module implements the **Qwik-inspired global delegation** pattern:
+ * This module implements the global delegation pattern:
  * - A single listener per event type is attached to `document.body` with
  *   `capture: true` (so it fires even for non-bubbling events).
  * - When an event fires, the handler walks up the DOM from `event.target`
- *   using `closest()` to find the nearest element with an `on-action`
- *   attribute whose event type matches.
+ *   using `closest()` to find the nearest element with an `on-<eventType>`
+ *   attribute (e.g. `on-click`, `on-submit`).
  * - Modifiers and payload resolvers run in the same pipeline as before.
  * - `dispatchAction` is called with the resolved payload.
  *
@@ -35,7 +35,7 @@
  * - `stop` stops further bubbling but the delegation handler has already
  *   captured the event at `body` level — it does not prevent other delegation
  *   handlers from running on the same element.
- * - `once` is emulated by delete attribute elements after first fire.
+ * - `once` is emulated by removing the attribute after first fire.
  */
 
 import {internalChannel_, logger_} from './lib.js';
@@ -44,65 +44,75 @@ import {modifierRegistry, payloadRegistry} from './registry.js';
 // ─── Syntax Parser ────────────────────────────────────────────────────────────
 
 /**
- * Parses the `on-action` attribute value into its three segments.
+ * Parses the `on-<eventType>` attribute value into its segments.
  *
- * Full syntax: `eventType[.modifier…]->actionId[:payload]`
+ * Syntax: `actionId[:payload][; modifier1,modifier2,…]`
  *
- * | Capture group | Matches                                     | Example              |
- * | ------------- | ------------------------------------------- | -------------------- |
- * | 1             | Event type + optional dot-chained modifiers | `click.prevent.once` |
- * | 2             | Action identifier                           | `open-drawer`        |
- * | 3             | Optional payload token or literal           | `main` / `$value`    |
+ * The event type is encoded in the **attribute name** itself (`on-click`,
+ * `on-submit`, etc.) rather than inside the value. This makes the HTML more
+ * readable and aligns with native event attribute conventions.
+ *
+ * | Capture group | Matches                                | Example                |
+ * | ------------- | -------------------------------------- | ---------------------- |
+ * | 1             | Action identifier                      | `open_drawer`          |
+ * | 2             | Optional payload token or literal      | `main_menu` / `$value` |
+ * | 3             | Optional comma-separated modifier list | `prevent,validate`     |
  *
  * @example
  * ```
- * 'click.prevent.once->open-drawer:main' → ['click.prevent.once', 'open-drawer', 'main']
- * 'input->search-query:$value'           → ['input',              'search-query', '$value']
- * 'submit.prevent->submit-form'          → ['submit.prevent',     'submit-form',  undefined]
+ * 'close_drawer'
+ *   → actionId='close_drawer', payload=undefined, modifiers={}
+ *
+ * 'open_drawer:main_menu'
+ *   → actionId='open_drawer', payload='main_menu', modifiers={}
+ *
+ * 'my_submit_handler:$formdata; prevent,validate'
+ *   → actionId='my_submit_handler', payload='$formdata', modifiers={'prevent','validate'}
  * ```
  */
-const syntaxRegex = /^([a-z0-9.-]+)->([a-z0-9-]+)(?::(.+))?$/;
+const syntaxRegex = /^([a-z0-9_-]+)(?::([a-z0-9_$-]+))?(?:;\s*([a-z0-9_,-]+))?$/;
 
 // ─── Parsed Action Descriptor ─────────────────────────────────────────────────
 
 /**
- * Parsed and cached representation of a single `on-action` attribute value.
+ * Parsed and cached representation of a single `on-<eventType>` attribute value.
  *
- * Caching avoids re-parsing the same attribute string on every event fire.
- * The cache is keyed by the raw attribute string so identical values share
- * the same descriptor object.
+ * Does not store `eventType` — the caller always has it from `event.type`,
+ * and the attribute name already encodes it (e.g. `on-click`), so storing it
+ * here would be redundant. This also keeps the cache key simple: just the raw
+ * attribute value string, with no composite key needed.
  */
 interface ActionDescriptor {
-  /** The DOM event type to listen for (e.g. `'click'`, `'input'`). */
-  readonly eventType: string;
   /** Set of active modifier names (e.g. `{'prevent', 'once'}`). */
   readonly modifiers: ReadonlySet<string>;
   /** The action identifier dispatched to `onAction` subscribers. */
   readonly actionId: string;
-  /** Raw payload token from the attribute (literal string or `$`-resolver key). */
+  /** Raw payload token from the attribute (literal string or $-resolver key). */
   readonly payload: string | undefined;
 }
 
 /**
- * LRU-style cache for parsed `on-action` attribute values.
+ * Cache for parsed `on-<eventType>` attribute values.
  *
  * Attribute strings are typically repeated across many elements (e.g. every
- * "add to cart" button shares the same `on-action` value). Caching the parsed
+ * "add to cart" button shares the same `on-click` value). Caching the parsed
  * descriptor avoids redundant regex work on every event.
  *
- * Using a plain `Map` here is intentional — attribute strings are short-lived
- * keys and the map size is bounded by the number of distinct `on-action` values
- * in the page, which is typically small.
+ * The cache key is the raw attribute value string. No composite key with
+ * event type is needed because the attribute name already encodes the event
+ * type — `on-click="open_drawer"` and `on-submit="open_drawer"` are two
+ * separate attributes with the same value string, but they are read from
+ * different attribute names and never collide in this cache.
  *
  * @internal
  */
 const descriptorCache__ = new Map<string, ActionDescriptor | null>();
 
 /**
- * Parses an `on-action` attribute value into an `ActionDescriptor`.
+ * Parses an `on-<eventType>` attribute value into an `ActionDescriptor`.
  *
  * Returns `null` when the syntax is invalid. Results are cached by the raw
- * attribute string so repeated calls for the same value are O(1).
+ * attribute value string so repeated calls for the same value are O(1).
  *
  * @internal
  */
@@ -120,23 +130,12 @@ function parseDescriptor__(attributeValue: string): ActionDescriptor | null {
     return null;
   }
 
-  const [eventType, ...modifierList] = match[1].split('.');
-  if (!eventType) {
-    logger_.accident('parseDescriptor__', 'missing_event_type', {attributeValue});
-    descriptorCache__.set(attributeValue, null);
-    return null;
-  }
-
-  const modifiers = new Set(modifierList);
-  const actionId = match[2];
-  const payload: string | undefined = match[3];
-
-  const descriptor: ActionDescriptor = {
-    eventType,
-    modifiers,
-    actionId,
-    payload,
-  };
+  const actionId = match[1];
+  const payload: string | undefined = match[2];
+  // match[3] is the raw modifier list string, e.g. "prevent,validate"
+  const modifierString = match[3];
+  const modifiers: Set<string> = modifierString ? new Set(modifierString.split(',')) : new Set();
+  const descriptor: ActionDescriptor = {modifiers, actionId, payload};
 
   descriptorCache__.set(attributeValue, descriptor);
   return descriptor;
@@ -144,16 +143,15 @@ function parseDescriptor__(attributeValue: string): ActionDescriptor | null {
 
 // ─── Core Delegation Handler ──────────────────────────────────────────────────
 
-const onActionAttrib__ = 'on-action';
 /**
  * Central event handler attached to `document.body` for every delegated event type.
  *
  * Execution flow for each incoming event:
  * 1. Walk up from `event.target` to find the nearest element with an
- *    `on-action` attribute whose event type matches the current event.
+ *    `on-<eventType>` attribute (e.g. `on-click`, `on-submit`).
  * 2. Parse (or retrieve from cache) the `ActionDescriptor` for that attribute.
  * 3. Run each modifier in order; if any returns `false`, abort.
- * 4. Resolve the payload token (literal or `$`-resolver).
+ * 4. Resolve the payload token (literal or $-resolver).
  * 5. Call `dispatchAction(actionId, payload)`.
  *
  * @internal
@@ -162,49 +160,45 @@ function handleDelegatedEvent__(event: Event): void {
   const eventType = event.type;
   logger_.logMethodArgs?.('handleDelegatedEvent__', {eventType});
 
-  // Walk up the DOM to find the closest element with a matching on-action attribute.
-  // We use `closest` on the composedPath target to support Shadow DOM correctly.
   const target = event.target as Element | null;
   if (!target) return;
 
-  // Find the nearest ancestor (or self) that has an on-action attribute
-  const actionElement = target.closest?.(`[${onActionAttrib__}^=${eventType}]`);
+  // Attribute name encodes the event type: on-click, on-submit, etc.
+  const actionAttrib = `on-${eventType}`;
+
+  // Walk up the DOM to find the closest element with the matching on-<eventType> attribute.
+  const actionElement = target.closest?.(`[${actionAttrib}]`);
   if (!actionElement) return;
 
-  const attributeValue = actionElement.getAttribute?.(onActionAttrib__)?.trim();
+  const attributeValue = actionElement.getAttribute?.(actionAttrib)?.trim();
   if (!attributeValue) {
-    logger_.accident('handleDelegatedEvent__', 'empty_attribute', {eventType, attributeValue, actionElement});
+    logger_.accident('handleDelegatedEvent__', 'empty_attribute', {eventType, actionElement});
     return;
   }
 
   if (!(actionElement instanceof HTMLElement)) {
-    logger_.accident('handleDelegatedEvent__', 'target_not_html_element', {eventType, attributeValue, actionElement});
+    logger_.accident('handleDelegatedEvent__', 'target_not_html_element', {eventType, actionElement});
     return;
   }
 
   const descriptor = parseDescriptor__(attributeValue);
-  if (!descriptor) {
-    logger_.accident('handleDelegatedEvent__', 'invalid_attribute', {eventType, attributeValue, actionElement});
-    return;
-  }
+  if (!descriptor) return;
 
-  if (descriptor.eventType !== eventType) return;
+  logger_.logMethodArgs?.('handleDelegatedEvent__.action', {eventType, descriptor});
 
-  logger_.logMethodArgs?.('handleDelegatedEvent__.action', descriptor);
-
-  // Step 1: handle once modifier
+  // Step 1: handle once modifier — remove attribute before running other modifiers
+  // so that even if a modifier aborts, the element will not fire again.
   if (descriptor.modifiers.has('once')) {
-    actionElement.removeAttribute(onActionAttrib__); // remove on-action to prevent repeat the action
-    descriptorCache__.delete(attributeValue); // free memory for once
+    actionElement.removeAttribute(actionAttrib);
   }
 
   // Step 2: run modifiers
   for (const modifier of descriptor.modifiers) {
-    if (modifier === 'once') continue; // handled separately
+    if (modifier === 'once') continue; // handled above
     const handler = modifierRegistry.get(modifier);
     if (!handler) {
-      logger_.accident('handleDelegatedEvent__', 'unknown_modifier', {modifier, attributeValue});
-      return; // unknown modifier — abort to avoid silent misbehaviour
+      logger_.accident('handleDelegatedEvent__', 'unknown_modifier', {eventType, modifier, attributeValue, descriptor});
+      return; // unknown modifier — abort to avoid silent misbehavior
     }
     if (handler(event, actionElement) === false) return;
   }
@@ -243,14 +237,14 @@ const delegatedEventTypes__ = new Set<string>();
  * Pass additional types to `setupActionDelegation` when your app uses other
  * events (e.g. `'keydown'`, `'pointerup'`).
  */
-export const DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', 'input', 'change'];
+export const DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', 'change'];
 
 /**
- * Registers global event delegation for `on-action` attributes.
+ * Registers global event delegation for `on-<eventType>` attributes.
  *
  * Attaches a single `capture`-phase listener on `document.body` for each
- * event type in `eventTypes`. All `on-action` processing — modifier execution,
- * payload resolution, and `dispatchAction` — happens inside that one handler.
+ * event type in `eventTypes`. All processing — modifier execution, payload
+ * resolution, and `dispatchAction` — happens inside that one handler.
  *
  * **Call this once at application bootstrap**, before any user interaction.
  * Subsequent calls with the same event types are no-ops (idempotent).
@@ -276,7 +270,7 @@ export const DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', '
  * // One call activates the entire page.
  * setupActionDelegation();
  *
- * onAction('open-drawer', (panel) => openDrawer(panel));
+ * onAction('open_drawer', (panel) => openDrawer(panel));
  * ```
  *
  * @example — with extra event types

--- a/pkg/nanolib/action/src/delegate.ts
+++ b/pkg/nanolib/action/src/delegate.ts
@@ -70,7 +70,7 @@ import {modifierRegistry, payloadRegistry} from './registry.js';
  *   → actionId='my_submit_handler', payload='$formdata', modifiers={'prevent','validate'}
  * ```
  */
-const syntaxRegex = /^([a-z0-9_-]+)(?::([a-z0-9_$-]+))?(?:;\s*([a-z0-9_,-]+))?$/;
+const syntaxRegex = /^([a-z0-9_-]+)(?::([^;]+))?(?:;\s*([a-z0-9_,-]+))?$/;
 
 // ─── Parsed Action Descriptor ─────────────────────────────────────────────────
 
@@ -134,7 +134,7 @@ function parseDescriptor__(attributeValue: string): ActionDescriptor | null {
   const payload: string | undefined = match[2];
   // match[3] is the raw modifier list string, e.g. "prevent,validate"
   const modifierString = match[3];
-  const modifiers: Set<string> = modifierString ? new Set(modifierString.split(',')) : new Set();
+  const modifiers: Set<string> = modifierString ? new Set(modifierString.split(',').filter(Boolean)) : new Set();
   const descriptor: ActionDescriptor = {modifiers, actionId, payload};
 
   descriptorCache__.set(attributeValue, descriptor);
@@ -237,7 +237,7 @@ const delegatedEventTypes__ = new Set<string>();
  * Pass additional types to `setupActionDelegation` when your app uses other
  * events (e.g. `'keydown'`, `'pointerup'`).
  */
-export const DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', 'change'];
+export const DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', 'input', 'change'];
 
 /**
  * Registers global event delegation for `on-<eventType>` attributes.

--- a/pkg/nanolib/action/src/delegate.ts
+++ b/pkg/nanolib/action/src/delegate.ts
@@ -237,7 +237,7 @@ const delegatedEventTypes__ = new Set<string>();
  * Pass additional types to `setupActionDelegation` when your app uses other
  * events (e.g. `'keydown'`, `'pointerup'`).
  */
-export const DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', 'change'];
+export const DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', 'input', 'change'];
 
 /**
  * Registers global event delegation for `on-<eventType>` attributes.

--- a/pkg/nanolib/action/src/main.ts
+++ b/pkg/nanolib/action/src/main.ts
@@ -1,17 +1,29 @@
 /**
  * @alwatr/action — Declarative DOM action-dispatch for Unidirectional Data Flow.
  *
- * ## Activating `on-action` attributes
+ * ## Activating `on-<eventType>` attributes
  *
  * Call `setupActionDelegation()` once at bootstrap. A single capture-phase
- * listener on `document.body` handles every `on-action` element — including
- * elements added dynamically after bootstrap — with O(1) initialization cost.
+ * listener on `document.body` handles every `on-click`, `on-submit`, etc. element —
+ * including elements added dynamically after bootstrap — with O(1) initialization cost.
  *
  * ```ts
  * import {setupActionDelegation, onAction} from '@alwatr/action';
  *
  * setupActionDelegation();
- * onAction('open-drawer', (panel) => openDrawer(panel));
+ * onAction('open_drawer', (panel) => openDrawer(panel));
+ * ```
+ *
+ * ## Attribute syntax
+ *
+ * ```
+ * on-<eventType>="actionId[:payload][; modifier1,modifier2,…]"
+ * ```
+ *
+ * ```html
+ * <button on-click="open_drawer:main">Open</button>
+ * <input on-input="search_query:$value" />
+ * <form on-submit="submit_form:$formdata; prevent,validate" novalidate>…</form>
  * ```
  *
  * ## Programmatic dispatch
@@ -30,8 +42,8 @@
  * // src/action-record.ts
  * declare module '@alwatr/action' {
  *   interface ActionRecord {
- *     'open-drawer': string;
- *     'add-to-cart': {productId: number; qty: number};
+ *     'open_drawer': string;
+ *     'add_to_cart': {productId: number; qty: number};
  *     'logout': void;
  *   }
  * }

--- a/pkg/nanolib/action/src/method.ts
+++ b/pkg/nanolib/action/src/method.ts
@@ -17,8 +17,8 @@ export type {ModifierHandler, PayloadResolver};
  * generic annotation needed:
  *
  * ```ts
- * // ActionRecord declares: 'add-to-cart': {productId: number; qty: number}
- * onAction('add-to-cart', (item) => {
+ * // ActionRecord declares: 'add_to_cart': {productId: number; qty: number}
+ * onAction('add_to_cart', (item) => {
  *   cartService.add(item.productId, item.qty); // fully typed, no `!` needed
  * });
  * ```
@@ -30,7 +30,7 @@ export type {ModifierHandler, PayloadResolver};
  * // src/action-record.ts
  * declare module '@alwatr/action' {
  *   interface ActionRecord {
- *     'open-drawer': string;
+ *     'open_drawer': string;
  *   }
  * }
  * ```
@@ -46,7 +46,7 @@ export type {ModifierHandler, PayloadResolver};
  * ```ts
  * import {onAction} from '@alwatr/action';
  *
- * const sub = onAction('page-ready', (pageId) => {
+ * const sub = onAction('page_ready', (pageId) => {
  *   router.setPage(pageId); // pageId: string — inferred from ActionRecord
  * });
  *
@@ -68,10 +68,10 @@ export function onAction<K extends keyof ActionRecord>(
  * automatically typed — passing the wrong type is a **compile error**:
  *
  * ```ts
- * // ActionRecord declares: 'add-to-cart': {productId: number; qty: number}
- * dispatchAction('add-to-cart', {productId: 42, qty: 1}); // ✅
- * dispatchAction('add-to-cart', 'wrong');                  // ❌ compile error
- * dispatchAction('unknown-action', 'x');                   // ❌ compile error
+ * // ActionRecord declares: 'add_to_cart': {productId: number; qty: number}
+ * dispatchAction('add_to_cart', {productId: 42, qty: 1}); // ✅
+ * dispatchAction('add_to_cart', 'wrong');                  // ❌ compile error
+ * dispatchAction('unknown_action', 'x');                   // ❌ compile error
  * ```
  *
  * Register new actions by extending `ActionRecord` via declaration merging:
@@ -88,7 +88,7 @@ export function onAction<K extends keyof ActionRecord>(
  *
  * Use `dispatchAction` when triggering an action from code — e.g. after an
  * async operation, from a service layer, or in tests. For DOM-driven actions,
- * use the `on-action` HTML attribute with `setupActionDelegation`.
+ * use the `on-<eventType>` HTML attribute with `setupActionDelegation`.
  *
  * @param actionId      - A key of `ActionRecord`.
  * @param actionPayload - The payload; type is enforced by `ActionRecord`.
@@ -97,7 +97,7 @@ export function onAction<K extends keyof ActionRecord>(
  * ```ts
  * import {dispatchAction} from '@alwatr/action';
  *
- * dispatchAction('page-ready', 'home');
+ * dispatchAction('page_ready', 'home');
  * dispatchAction('navigate', '/dashboard');
  * ```
  *
@@ -117,10 +117,10 @@ export function dispatchAction<K extends keyof ActionRecord>(
 // ─── Extension API ────────────────────────────────────────────────────────────
 
 /**
- * Registers a custom modifier that can be used in `on-action` attribute syntax.
+ * Registers a custom modifier that can be used in `on-<eventType>` attribute syntax.
  *
- * A modifier is a dot-chained token placed after the event type
- * (e.g. `click.mymod->action-id`). Its handler runs before the payload is
+ * A modifier is a comma-separated token placed after the `;` separator
+ * (e.g. `on-click="action-id; mymod"`). Its handler runs before the payload is
  * resolved and the action is dispatched. Returning `false` cancels the dispatch.
  *
  * Built-in modifiers (`prevent`, `stop`, `validate`, `once`) are always
@@ -129,7 +129,7 @@ export function dispatchAction<K extends keyof ActionRecord>(
  * Registering the same name twice logs an accident and overwrites the previous
  * handler — avoid duplicate registrations in production code.
  *
- * @param name    - The modifier token (lowercase, no dots or arrows).
+ * @param name    - The modifier token (lowercase, no special characters).
  * @param handler - A `ModifierHandler` receiving `(event, element)`.
  *
  * @example — a `confirm` modifier that shows a browser dialog
@@ -139,7 +139,7 @@ export function dispatchAction<K extends keyof ActionRecord>(
  * registerModifier('confirm', () => window.confirm('Are you sure?'));
  * ```
  * ```html
- * <button on-action="click.confirm->delete-item:42">Delete</button>
+ * <button on-click="delete_item:42; confirm">Delete</button>
  * ```
  */
 export function registerModifier(name: string, handler: ModifierHandler): void {
@@ -151,10 +151,10 @@ export function registerModifier(name: string, handler: ModifierHandler): void {
 }
 
 /**
- * Registers a custom payload resolver that can be used in `on-action` attribute syntax.
+ * Registers a custom payload resolver that can be used in `on-<eventType>` attribute syntax.
  *
- * A payload resolver is a colon-suffixed token in the attribute value
- * (e.g. `click->action-id:$mytoken`). Its function is called at dispatch time
+ * A payload resolver is a colon-prefixed token in the attribute value
+ * (e.g. `on-click="action-id:$mytoken"`). Its function is called at dispatch time
  * with an `ActionContext` as `this` and the DOM event as the argument.
  * The return value becomes the `actionPayload` passed to `onAction` subscribers.
  *
@@ -176,7 +176,7 @@ export function registerModifier(name: string, handler: ModifierHandler): void {
  * });
  * ```
  * ```html
- * <input type="checkbox" on-action="change->toggle-feature:$checked" />
+ * <input type="checkbox" on-change="toggle_feature:$checked" />
  * ```
  */
 export function registerPayloadResolver(name: string, resolver: PayloadResolver): void {

--- a/pkg/nanolib/action/src/registry.ts
+++ b/pkg/nanolib/action/src/registry.ts
@@ -45,8 +45,8 @@ export type PayloadResolver = (event: Event, element: HTMLElement) => unknown;
 /**
  * Registry of all named modifier handlers.
  *
- * Keys are modifier names used in the `on-action` attribute syntax
- * (e.g. `click.prevent->action-id`). Values are `ModifierHandler` functions.
+ * Keys are modifier names used in the `on-<eventType>` attribute syntax
+ * (e.g. `on-click="action-id; prevent"`). Values are `ModifierHandler` functions.
  * Populated at module load with built-in modifiers; extended at runtime via
  * `registerModifier`.
  *
@@ -57,8 +57,8 @@ export const modifierRegistry = new Map<string, ModifierHandler>();
 /**
  * Registry of all named payload resolvers.
  *
- * Keys are resolver tokens used in the `on-action` attribute syntax
- * (e.g. `click->action-id:$value`). Values are `PayloadResolver` functions.
+ * Keys are resolver tokens used in the `on-<eventType>` attribute syntax
+ * (e.g. `on-input="search_query:$value"`). Values are `PayloadResolver` functions.
  * Populated at module load with built-in resolvers; extended at runtime via
  * `registerPayloadResolver`.
  *
@@ -74,7 +74,7 @@ export const payloadRegistry = new Map<string, PayloadResolver>();
  * Use it to suppress the browser's default behaviour (e.g. form submission,
  * link navigation, context menu).
  *
- * @example `<form on-action="submit.prevent->submit-form">`
+ * @example `<form on-submit="submit-form; prevent">`
  */
 modifierRegistry.set('prevent', (event) => {
   event.preventDefault();
@@ -91,7 +91,7 @@ modifierRegistry.set('prevent', (event) => {
  *
  * Pair with `.prevent` on `submit` events to avoid page reloads:
  *
- * @example `<form on-action="submit.prevent.validate->submit-form:$formdata" novalidate>`
+ * @example `<form on-submit="submit_form:$formdata; prevent,validate" novalidate>`
  */
 modifierRegistry.set('validate', (_event, element) => {
   const form = element instanceof HTMLFormElement ? element : element.closest('form');
@@ -107,7 +107,7 @@ modifierRegistry.set('validate', (_event, element) => {
  * Works with any element that exposes a `value` property: `<input>`,
  * `<textarea>`, `<select>`. Returns `null` for elements without `.value`.
  *
- * @example `<input on-action="input->search-query:$value" />`
+ * @example `<input on-input="search_query:$value" />`
  */
 payloadRegistry.set('$value', (_event, element) => {
   return 'value' in element ? (element as {value: unknown}).value : null;
@@ -120,9 +120,9 @@ payloadRegistry.set('$value', (_event, element) => {
  * Looks for a `<form>` ancestor (or the element itself). Returns `null` when no
  * form is found.
  *
- * @example `<form on-action="submit.prevent.validate->submit-form:$formdata">`
+ * @example `<form on-submit="submit_form:$formdata; prevent,validate">`
  * ```ts
- * onAction('submit-form', (data) => {
+ * onAction('submit_form', (data) => {
  *   console.log(data); // {username: 'ali', password: '…'}
  * });
  * ```


### PR DESCRIPTION
## Description

Update the action delegation pattern to use event-type-specific attributes, changing the syntax from `on-action` to `on-<eventType>`. This includes modifications to the action value syntax and documentation to reflect the new naming convention in snake_case. The changes enhance readability and align with native HTML event attribute conventions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## یادداشت‌های انتشار

* **اسناد و راهنماها**
  * بازنویسی README و مستندات داخلی با نحو جدید صریح DOM و مثال‌های به‌روز (کلیک/ورودی/فرم/once).
  * اصلاح جداول نحو خصوصیات و فهرست اصلاح‌کننده‌های داخلی.
  * به‌روزرسانی نمودار جریان داده و مثال‌های ثبت‌کننده/حل‌کننده‌ها.

* **تغییرات اساسی**
  * نحو خصوصیات از `on-action` به `on-<eventType>` تغییر یافت.
  * سینتکس اصلاح‌کننده‌ها به جداکنندهٔ `;` و نام‌های اصلاح‌کننده با زیرخط مستند شد.
  * قرارداد نام‌گذاری اقدامات از kebab-case به snake_case تغییر یافت.
  * حذف توضیح قبلی دربارهٔ رفتار `once` مبتنی بر WeakSet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->