### PR TITLE
Add LitDirective and reactive state management features

### DIFF
--- a/.kiro/hooks/sync-docs-on-source-change.kiro.hook
+++ b/.kiro/hooks/sync-docs-on-source-change.kiro.hook
@@ -1,0 +1,15 @@
+{
+  "enabled": true,
+  "name": "Sync Docs on Source Change",
+  "description": "Manually triggered before a commit. Detects changed files via git diff and updates JSDoc, README, and /docs accordingly.",
+  "version": "1",
+  "when": {
+    "type": "userTriggered"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "Run `git diff --name-only --cached` to get the list of all staged files (files that have been `git add`-ed and are ready to commit). Review each changed file and update documentation where needed, following these rules:\n\n1. **JSDoc in .ts files**: For any changed `.ts` file, update or add JSDoc comments (`/** ... */`) on exported functions, classes, interfaces, types, or constants that were added or modified. Preserve all existing JSDoc — only extend or correct it, never remove it. Use `@param`, `@returns`, `@throws`, `@example`, and `@remarks` tags as appropriate.\n\n2. **README.md**: Update the README.md in the same package directory (e.g. `pkg/<name>/README.md`), or the root README.md for root-level changes. Preserve all existing sections and content — only add, update, or extend relevant parts (API reference, usage examples, configuration). Never remove existing documentation.\n\n3. **/docs folder**: If a `/docs` folder exists in the package or repo root, update the relevant file(s) there too. Again, preserve existing content.\n\n4. **Scope**: Only update docs when the change affects public API, exported behavior, configuration, or usage patterns. Skip purely internal refactors, private member renames, or trivial edits.\n\n5. **Language**: All documentation and comments must be written in fluent English."
+  },
+  "workspaceFolderName": "alwatr-devkit",
+  "shortName": "sync-docs-on-source-change"
+}

--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,7 @@
       "dependencies": {
         "@alwatr/delay": "workspace:*",
         "@alwatr/logger": "workspace:*",
+        "lit-html": "^3.3.2",
       },
       "devDependencies": {
         "@alwatr/nano-build": "workspace:*",
@@ -942,6 +943,8 @@
 
     "@types/parse-path": ["@types/parse-path@7.1.0", "", { "dependencies": { "parse-path": "*" } }, "sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -1115,6 +1118,8 @@
     "libnpmpublish": ["libnpmpublish@11.1.3", "", { "dependencies": { "@npmcli/package-json": "^7.0.0", "ci-info": "^4.0.0", "npm-package-arg": "^13.0.0", "npm-registry-fetch": "^19.0.0", "proc-log": "^6.0.0", "semver": "^7.3.7", "sigstore": "^4.0.0", "ssri": "^13.0.0" } }, "sha512-NVPTth/71cfbdYHqypcO9Lt5WFGTzFEcx81lWd7GDJIgZ95ERdYHGUfCtFejHCyqodKsQkNEx2JCkMpreDty/A=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lit-html": ["lit-html@3.3.2", "", { "dependencies": { "@types/trusted-types": "^2.0.2" } }, "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw=="],
 
     "load-json-file": ["load-json-file@7.0.1", "", {}, "sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ=="],
 

--- a/pkg/nanolib/directive/README.md
+++ b/pkg/nanolib/directive/README.md
@@ -171,10 +171,16 @@ new Directive(element, attributeName)
   │    sets: attributeName, attributeValue, element_, logger_, index
   │
   └─ after one macrotask (delay.nextMacrotask)
-       ├─ init_()?       ← optional — runs once (setup, event listeners)
+       ├─ init_()?       ← optional — runs once (setup, event listeners, signal subscriptions)
        ├─ lazyInit_()?   ← optional — runs once, when element first enters viewport
        ├─ onVisible_()?  ← optional — runs every time element enters viewport
        └─ onHidden_()?   ← optional — runs every time element leaves viewport
+
+state change (via @state accessor or StateSignal subscription)
+  │
+  └─ requestUpdate_()   ← batched, collapses multiple calls into one macrotask
+       ├─ update_()     ← DOM mutations / lit-html render() [LitDirective]
+       └─ updated_()    ← post-render hook
 ```
 
 The macrotask delay ensures the full DOM subtree is painted and settled before your directive runs — no race conditions with sibling elements or CSS.
@@ -456,7 +462,205 @@ document.addEventListener('form-submitted', (e: CustomEvent) => {
 
 ---
 
-## Utility Decorators
+## Reactive Rendering — `requestUpdate_()`, `update_()`, `updated_()`
+
+`Directive` includes a lightweight batched update cycle for directives that need to re-render their DOM in response to state changes.
+
+### The update cycle
+
+```
+state change
+  │
+  └─ requestUpdate_()     ← schedules one macrotask (multiple calls collapse into one)
+       │
+       ├─ update_()       ← perform DOM mutations / call lit-html render()
+       └─ updated_()      ← post-render hook (focus, measure, dispatch events)
+```
+
+### Triggering an update
+
+There are three idiomatic ways to start the cycle:
+
+**1. `@state` accessor (most common — local state)**
+
+Setting a `@state`-decorated accessor automatically calls `requestUpdate_()`:
+
+```ts
+@directive('like-button')
+class LikeButtonDirective extends Directive {
+  @state()
+  accessor liked_: string | null = null;
+
+  protected override init_(): void {
+    this.liked_ = 'false'; // triggers first update
+    this.on_('click', () => {
+      this.liked_ = this.liked_ === 'true' ? 'false' : 'true'; // triggers re-render
+    });
+  }
+
+  protected override update_(): void {
+    this.element_.classList.toggle('liked', this.liked_ === 'true');
+  }
+}
+```
+
+**2. `StateSignal` subscription (shared application state)**
+
+Subscribe to a signal in `init_()` and call `requestUpdate_()` from the callback:
+
+```ts
+@directive('cart-badge')
+class CartBadgeDirective extends Directive {
+  private count_ = 0;
+
+  protected override init_(): void {
+    const sub = cartSignal.subscribe((cart) => {
+      this.count_ = cart.items.length;
+      this.requestUpdate_();
+    });
+    this.addDestroyHook(() => sub.unsubscribe());
+  }
+
+  protected override update_(): void {
+    this.element_.textContent = String(this.count_);
+  }
+}
+```
+
+**3. Manual call (imperative mutations)**
+
+Call `requestUpdate_()` directly after mutating non-`@state` internal state:
+
+```ts
+protected override init_(): void {
+  this.on_('click', () => {
+    this.count_++;
+    this.requestUpdate_();
+  });
+}
+```
+
+### `update_()`
+
+Override to perform DOM mutations. Called once per scheduled cycle, synchronously inside the macrotask. `LitDirective` overrides this to call `lit-html`'s `render()`.
+
+### `updated_()`
+
+Override to run post-render logic — measuring layout, focusing an element, or dispatching a `CustomEvent`:
+
+```ts
+protected override updated_(): void {
+  this.element_.querySelector<HTMLElement>('.active-item')?.focus();
+}
+```
+
+---
+
+## `LitDirective` — Declarative Templates with `lit-html`
+
+`LitDirective` extends `Directive` and adds a `render_()` hook that integrates `lit-html`. Use it when you want to describe a directive's DOM output as a declarative template instead of imperative DOM mutations.
+
+```ts
+import {directive, LitDirective, state} from '@alwatr/directive';
+import {html} from 'lit-html';
+
+@directive('cart-badge')
+export class CartBadgeDirective extends LitDirective {
+  @state()
+  accessor count_: string | null = null;
+
+  protected override init_(): void {
+    // StateSignal.subscribe() calls the callback immediately with the current value,
+    // so the first render happens right after init_() without any extra trigger.
+    const sub = cartSignal.subscribe((cart) => {
+      this.count_ = String(cart.items.length); // @state setter calls requestUpdate_()
+    });
+    this.addDestroyHook(() => sub.unsubscribe());
+  }
+
+  protected override render_() {
+    return html`
+      <span class="badge">${this.count_ ?? '0'}</span>
+    `;
+  }
+}
+```
+
+```html
+<div cart-badge></div>
+```
+
+### `render_()`
+
+The only method you must implement. Return any value accepted by `lit-html`'s `render()` — typically an `html` tagged template literal. Keep it pure and side-effect-free; all side effects belong in `update_()` or `updated_()`.
+
+### `rootElement_`
+
+By default `lit-html` renders into `this.element_`. Override `rootElement_` to redirect rendering into a different container:
+
+```ts
+@directive('shadow-card')
+class ShadowCardDirective extends LitDirective {
+  protected override rootElement_ = this.element_.attachShadow({mode: 'open'}) as unknown as HTMLElement;
+
+  protected override render_() {
+    return html`
+      <slot></slot>
+    `;
+  }
+}
+```
+
+### When to use `LitDirective` vs `Directive`
+
+| Scenario                                             | Use            |
+| ---------------------------------------------------- | -------------- |
+| Simple DOM mutations, event listeners, class toggles | `Directive`    |
+| Complex, data-driven templates that change shape     | `LitDirective` |
+| Subscribing to signals and re-rendering a template   | `LitDirective` |
+
+---
+
+## `@state` — Reactive Local State
+
+`@state` marks an `accessor` as reactive. Every time the accessor is set, `requestUpdate_()` is called automatically — no manual trigger needed.
+
+```ts
+@state()
+accessor count_: string | null = null;
+```
+
+**Rules:**
+
+- Requires the `accessor` keyword (TC39 Stage 3 auto-accessor)
+- No deep-equality check — every `set` schedules an update, even with the same value
+- For **shared** state, use a `StateSignal` subscription instead (see above)
+
+**Combining `@state` with `StateSignal`** is the standard pattern for reactive directives:
+
+```ts
+@directive('user-avatar')
+class UserAvatarDirective extends LitDirective {
+  @state()
+  accessor avatarUrl_: string | null = null;
+
+  protected override init_(): void {
+    const sub = userSignal.subscribe((user) => {
+      this.avatarUrl_ = user.avatarUrl; // @state triggers re-render on each emission
+    });
+    this.addDestroyHook(() => sub.unsubscribe());
+  }
+
+  protected override render_() {
+    return html`
+      <img
+        src=${this.avatarUrl_ ?? '/default-avatar.png'}
+        alt="avatar"
+      />
+    `;
+  }
+}
+```
 
 These TC39 Stage 3 accessor decorators reduce boilerplate for common patterns inside directives. They require the `accessor` keyword.
 
@@ -595,10 +799,23 @@ Class decorator. Registers the decorated class in the global directive registry.
 | `lazyInit_()?`             | `protected`                                       | Optional — runs once when element first enters the viewport                                                                                                             |
 | `onVisible_()?`            | `protected`                                       | Optional — runs every time element enters the viewport                                                                                                                  |
 | `onHidden_()?`             | `protected`                                       | Optional — runs every time element leaves the viewport                                                                                                                  |
+| `requestUpdate_()`         | `public`                                          | Schedules a batched `update_()` + `updated_()` call for the next macrotask. Multiple calls within the same cycle collapse into one.                                     |
+| `update_()`                | `protected`                                       | Called once per update cycle — override to perform DOM mutations. `LitDirective` overrides this to call `lit-html`'s `render()`.                                        |
+| `updated_()`               | `protected`                                       | Called immediately after `update_()` — override for post-render logic (focus, measure, dispatch events).                                                                |
 | `dispatch(event, detail?)` | `public`                                          | Fires a bubbling `CustomEvent` from `element_`                                                                                                                          |
 | `addDestroyHook(task)`     | `public`                                          | Registers an async cleanup callback                                                                                                                                     |
 | `destroy()`                | `public async`                                    | Runs all destroy hooks, then nullifies `element_`                                                                                                                       |
 | `autoDestroy()`            | `public`                                          | Destroys if element is disconnected; returns `true` if destroyed                                                                                                        |
+
+---
+
+### `LitDirective` (abstract class, extends `Directive`)
+
+| Member         | Type                                 | Description                                                                                                           |
+| -------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `rootElement_` | `protected HTMLElement \| undefined` | The container `lit-html` renders into. Defaults to `element_`. Override to redirect rendering (e.g. Shadow DOM root). |
+| `render_()`    | `protected abstract`                 | **Must implement.** Returns the `lit-html` template for each update cycle. Keep it pure — no side effects.            |
+| `update_()`    | `protected override`                 | Calls `render_()` and passes the result to `lit-html`'s `render()`. Do not call directly — use `requestUpdate_()`.    |
 
 ---
 
@@ -615,6 +832,16 @@ Scans `root` (default: `document.body`) for elements matching registered attribu
 ### `autoDestructDirectives()`
 
 Iterates all live directive instances and calls `autoDestroy()` on each. Removes destroyed instances from the internal registry.
+
+---
+
+### `state()`
+
+Accessor decorator. Marks the accessor as reactive local state — every `set` call automatically schedules a re-render via `requestUpdate_()`.
+
+- No deep-equality check — every assignment schedules an update
+- **Requires `accessor` keyword**
+- For shared application state, use a `StateSignal` subscription instead
 
 ---
 

--- a/pkg/nanolib/directive/README.md
+++ b/pkg/nanolib/directive/README.md
@@ -632,7 +632,7 @@ accessor count_: string | null = null;
 
 **Rules:**
 
-- Requires the `accessor` keyword (TC39 Stage 3 auto-accessor)
+- Requires the `accessor` keyword (ES2024 auto-accessor feature)
 - No deep-equality check — every `set` schedules an update, even with the same value
 - For **shared** state, use a `StateSignal` subscription instead (see above)
 

--- a/pkg/nanolib/directive/package.json
+++ b/pkg/nanolib/directive/package.json
@@ -22,7 +22,8 @@
   "sideEffects": false,
   "dependencies": {
     "@alwatr/delay": "workspace:*",
-    "@alwatr/logger": "workspace:*"
+    "@alwatr/logger": "workspace:*",
+    "lit-html": "^3.3.2"
   },
   "devDependencies": {
     "@alwatr/nano-build": "workspace:*",

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -162,12 +162,16 @@ export abstract class Directive {
     delay.nextMacrotask().then(() => this.initializeLifecycle_());
   }
 
+  /**
+   * Initializes the directive's lifecycle by calling the `init_` method and setting up any necessary observers for lazy initialization and visibility tracking. This method is called after the directive instance is created and the initial attribute value is parsed.
+   */
   private async initializeLifecycle_(): Promise<void> {
     try {
       await this.init_?.();
     } catch (err) {
       this.logger_.error('init_', 'error_in_init', err);
     }
+
     if (this.lazyInit_) {
       this.triggerLazyInit_();
     }
@@ -407,5 +411,88 @@ export abstract class Directive {
     const boundListener = listener.bind(this);
     element.addEventListener(eventType, boundListener as EventListener, options);
     this.addDestroyHook(() => element.removeEventListener(eventType, boundListener as EventListener, options));
+  }
+
+  private isUpdatePending_ = false;
+
+  /**
+   * Schedules a batched re-render for the next macrotask.
+   *
+   * Calling this method multiple times within the same macrotask cycle is safe — only one
+   * `update_()` + `updated_()` pair will be executed. Subsequent calls while an update is
+   * already pending are silently ignored.
+   *
+   * **You rarely need to call this directly.** The two idiomatic triggers are:
+   * - A `@state`-decorated accessor — calls `requestUpdate_()` automatically on every `set`.
+   * - A `StateSignal` subscription — call `requestUpdate_()` inside the callback.
+   *
+   * @example — Triggered automatically by `@state` (most common)
+   * ```ts
+   * // Setting a @state accessor schedules the update — no manual call needed.
+   * this.count_ = newValue;
+   * ```
+   *
+   * @example — Triggered manually from a `StateSignal` subscription
+   * ```ts
+   * protected override init_(): void {
+   *   const sub = cartSignal.subscribe(() => this.requestUpdate_());
+   *   this.addDestroyHook(() => sub.unsubscribe());
+   * }
+   * ```
+   *
+   * @example — Triggered manually after mutating non-`@state` internal state
+   * ```ts
+   * protected override init_(): void {
+   *   this.on_('click', () => {
+   *     this.count_++;
+   *     this.requestUpdate_();
+   *   });
+   * }
+   * ```
+   */
+  public requestUpdate_(): void {
+    this.logger_.logMethod?.('requestUpdate_');
+    if (this.isUpdatePending_) return;
+    this.isUpdatePending_ = true;
+    delay.nextMacrotask().then(() => {
+      this.update_();
+      this.isUpdatePending_ = false;
+      this.updated_();
+    });
+  }
+
+  /**
+   * Called during each scheduled update cycle, immediately before `updated_()`.
+   *
+   * Override this method to perform DOM mutations or re-renders in response to state changes.
+   * The base implementation is a no-op — subclasses such as `LitDirective` override it to call
+   * `lit-html`'s `render()`.
+   *
+   * This method is always called synchronously within the macrotask scheduled by `requestUpdate_()`.
+   * Do **not** call `requestUpdate_()` from inside `update_()` — it will be ignored because the
+   * pending flag is still set at that point.
+   */
+  protected update_(): void {
+    this.logger_.logMethod?.('update_');
+  }
+
+  /**
+   * Called immediately after `update_()` completes in each update cycle.
+   *
+   * Override this method to run post-render logic — e.g. measuring DOM dimensions, focusing an
+   * element, or dispatching a `CustomEvent` to notify the outside world that the view has changed.
+   *
+   * The base implementation is a no-op.
+   *
+   * @example
+   * ```ts
+   * protected override updated_(): void {
+   *   // Scroll the newly rendered content into view after each update
+   *   this.element_.querySelector('.active-item')?.scrollIntoView({behavior: 'smooth'});
+   * }
+   * ```
+   */
+  protected updated_(): void {
+    this.logger_.logMethod?.('updated_');
   }
 }

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -455,8 +455,11 @@ export abstract class Directive {
     if (this.isUpdatePending_) return;
     this.isUpdatePending_ = true;
     delay.nextMacrotask().then(() => {
-      this.update_();
-      this.isUpdatePending_ = false;
+      try {
+        this.update_();
+      } finally {
+        this.isUpdatePending_ = false;
+      }
       this.updated_();
     });
   }
@@ -495,4 +498,6 @@ export abstract class Directive {
   protected updated_(): void {
     this.logger_.logMethod?.('updated_');
   }
+
+  protected subscribe_(tar);
 }

--- a/pkg/nanolib/directive/src/lit-directive.ts
+++ b/pkg/nanolib/directive/src/lit-directive.ts
@@ -1,0 +1,144 @@
+/**
+ * @package @alwatr/directive
+ *
+ * This file defines `LitDirective` — a `Directive` subclass that integrates `lit-html` for
+ * declarative template rendering. Extend it when you want to manage a directive's DOM output
+ * through a `render_()` method that returns a `lit-html` `TemplateResult`.
+ */
+
+import {render} from 'lit-html';
+import {Directive} from './directive-class.js';
+
+/**
+ * A `Directive` subclass that renders its DOM output using `lit-html`.
+ *
+ * Extend `LitDirective` instead of `Directive` when you want to describe the directive's view
+ * as a declarative `lit-html` template. Every time `requestUpdate_()` is called — either
+ * manually or automatically by a `@state`-decorated accessor — `update_()` runs, which calls
+ * `render_()` and passes the result to `lit-html`'s `render()`.
+ *
+ * The update cycle is always **batched**: multiple `requestUpdate_()` calls within the same
+ * macrotask collapse into a single `render_()` invocation.
+ *
+ * By default the template is rendered into `this.element_`. Override `rootElement_` to redirect
+ * rendering into a different container (e.g. a Shadow DOM root or a child element).
+ *
+ * ---
+ *
+ * ### Update cycle
+ *
+ * ```
+ * state change (set @state accessor  OR  signal subscription callback)
+ *   │
+ *   └─ requestUpdate_()          ← schedules one macrotask (batched)
+ *        │
+ *        ├─ update_()            ← calls render_() via lit-html render()
+ *        └─ updated_()           ← post-render hook (focus, measure, etc.)
+ * ```
+ *
+ * ---
+ *
+ * @example — Local state with `@state`
+ * ```ts
+ * import {directive, LitDirective, state} from '@alwatr/directive';
+ * import {html} from 'lit-html';
+ *
+ * @directive('like-button')
+ * export class LikeButtonDirective extends LitDirective {
+ *   \@state()
+ *   accessor liked_: string | null = null;
+ *
+ *   protected override init_(): void {
+ *     this.liked_ = 'false'; // first assignment triggers the initial render
+ *     this.on_('click', () => {
+ *       this.liked_ = this.liked_ === 'true' ? 'false' : 'true';
+ *     });
+ *   }
+ *
+ *   protected override render_() {
+ *     return html`<button class=${this.liked_ === 'true' ? 'liked' : ''}>♥</button>`;
+ *   }
+ * }
+ * ```
+ *
+ * @example — Shared state via `StateSignal`
+ * ```ts
+ * import {directive, LitDirective, state} from '@alwatr/directive';
+ * import {html} from 'lit-html';
+ * import {cartSignal} from '../signals/cart.js';
+ *
+ * @directive('cart-badge')
+ * export class CartBadgeDirective extends LitDirective {
+ *   \@state()
+ *   accessor count_: string | null = null;
+ *
+ *   protected override init_(): void {
+ *     // cartSignal.subscribe() calls the callback immediately with the current value,
+ *     // so the first render happens right after init_() without any extra trigger.
+ *     const sub = cartSignal.subscribe((cart) => {
+ *       this.count_ = String(cart.items.length); // @state setter calls requestUpdate_()
+ *     });
+ *     this.addDestroyHook(() => sub.unsubscribe());
+ *   }
+ *
+ *   protected override render_() {
+ *     return html`<span class="badge">${this.count_ ?? '0'}</span>`;
+ *   }
+ * }
+ * ```
+ *
+ * ```html
+ * <div cart-badge></div>
+ * ```
+ */
+export abstract class LitDirective extends Directive {
+  /**
+   * The element into which `lit-html` renders the template.
+   *
+   * Defaults to `this.element_` (the directive's bound element). Override this field in your
+   * subclass to redirect rendering — for example, into a Shadow DOM root or a dedicated child
+   * container — without changing any other lifecycle logic.
+   *
+   * @example
+   * ```ts
+   * @directive('shadow-card')
+   * class ShadowCardDirective extends LitDirective {
+   *   protected override rootElement_ = this.element_.attachShadow({mode: 'open'}) as unknown as HTMLElement;
+   *
+   *   protected override render_() {
+   *     return html`<slot></slot>`;
+   *   }
+   * }
+   * ```
+   */
+  protected rootElement_?: HTMLElement;
+
+  /**
+   * Renders the `lit-html` template returned by `render_()` into `rootElement_` (or `element_`).
+   *
+   * This method is called automatically by `requestUpdate_()` during each scheduled update cycle.
+   * Do not call it directly — use `requestUpdate_()` instead to ensure batching.
+   */
+  protected override update_(): void {
+    super.update_();
+    const rootElement = this.rootElement_ ?? this.element_;
+    render(this.render_(), rootElement, {host: this});
+  }
+
+  /**
+   * Returns the `lit-html` template to render on each update cycle.
+   *
+   * Implement this method in your subclass to describe the directive's DOM output declaratively.
+   * It is called by `update_()` on every scheduled render — keep it pure and side-effect-free.
+   *
+   * @returns A `lit-html` `TemplateResult` (or any value accepted by `lit-html`'s `render()`).
+   *
+   * @example
+   * ```ts
+   * protected override render_() {
+   *   return html`<span class="badge">${this.count_}</span>`;
+   * }
+   * ```
+   */
+  protected abstract render_(): unknown;
+}

--- a/pkg/nanolib/directive/src/main.ts
+++ b/pkg/nanolib/directive/src/main.ts
@@ -2,4 +2,5 @@ export * from './bootstrap.js';
 export * from './auto-destruct.js';
 export * from './directive-decorator.js';
 export * from './directive-class.js';
+export * from './lit-directive.js';
 export * from './util-decorators.js';

--- a/pkg/nanolib/directive/src/util-decorators.ts
+++ b/pkg/nanolib/directive/src/util-decorators.ts
@@ -133,6 +133,94 @@ export function attribute<D extends Directive = Directive>(name: string, cache =
 }
 
 /**
+ * A property decorator that marks an accessor as reactive local state.
+ *
+ * When the accessor's value is set, `requestUpdate_()` is called automatically on the directive
+ * instance, scheduling a batched re-render for the next macrotask.
+ *
+ * This is the primary way to drive `LitDirective` re-renders from **local** state changes
+ * (values owned by the directive itself). For **shared** application state, subscribe to a
+ * `StateSignal` inside `init_()` and call `requestUpdate_()` from the subscription callback —
+ * see the signal example below.
+ *
+ * The decorator is a thin wrapper around the native accessor — it does **not** perform any
+ * deep-equality check. Every `set` call (even with the same value) will schedule an update.
+ *
+ * @remarks
+ * The `name`, `cache`, and `root` parameters are accepted for API symmetry with `@attribute`
+ * but are currently unused. They are reserved for future use (e.g. persisting state to an
+ * attribute or reading the initial value from the DOM).
+ *
+ * @example — Local state (owned by the directive)
+ * ```ts
+ * import {directive, LitDirective, state} from '@alwatr/directive';
+ * import {html} from 'lit-html';
+ *
+ * @directive('like-button')
+ * class LikeButtonDirective extends LitDirective {
+ *   \@state()
+ *   accessor liked_: string | null = null;
+ *
+ *   protected override init_(): void {
+ *     this.liked_ = 'false'; // triggers first render
+ *     this.on_('click', () => {
+ *       this.liked_ = this.liked_ === 'true' ? 'false' : 'true'; // triggers re-render
+ *     });
+ *   }
+ *
+ *   protected override render_() {
+ *     return html`<button class=${this.liked_ === 'true' ? 'liked' : ''}>♥</button>`;
+ *   }
+ * }
+ * ```
+ *
+ * @example — Shared state via `StateSignal` subscription
+ * ```ts
+ * import {directive, LitDirective, state} from '@alwatr/directive';
+ * import {html} from 'lit-html';
+ * import {cartSignal} from '../signals/cart.js';
+ *
+ * @directive('cart-badge')
+ * class CartBadgeDirective extends LitDirective {
+ *   \@state()
+ *   accessor count_: string | null = null;
+ *
+ *   protected override init_(): void {
+ *     // Subscribe to the shared signal; each emission sets count_ and triggers a re-render.
+ *     const sub = cartSignal.subscribe((cart) => {
+ *       this.count_ = String(cart.items.length);
+ *     });
+ *     this.addDestroyHook(() => sub.unsubscribe());
+ *   }
+ *
+ *   protected override render_() {
+ *     return html`<span class="badge">${this.count_ ?? '0'}</span>`;
+ *   }
+ * }
+ * ```
+ */
+export function state<D extends Directive = Directive>(_name?: string, _cache = true, _root?: Element) {
+  return function (
+    target: ClassAccessorDecoratorTarget<D, string | null>,
+    context: ClassAccessorDecoratorContext<D, string | null>,
+  ): ClassAccessorDecoratorResult<D, string | null> {
+    if (context.kind !== 'accessor') {
+      throw new Error('@state can only be used with the "accessor" keyword');
+    }
+
+    return {
+      get(this: D) {
+        return target.get.call(this);
+      },
+      set(this: D, value) {
+        target.set.call(this, value);
+        this.requestUpdate_();
+      },
+    };
+  };
+}
+
+/**
  * A method decorator that registers a DOM event listener on the directive's element (or a matching
  * child element when a CSS selector is provided). The listener is automatically removed when the
  * directive is destroyed, preventing memory leaks.

--- a/pkg/nanolib/directive/src/util-decorators.ts
+++ b/pkg/nanolib/directive/src/util-decorators.ts
@@ -199,7 +199,7 @@ export function attribute<D extends Directive = Directive>(name: string, cache =
  * }
  * ```
  */
-export function state<D extends Directive = Directive>(_name?: string, _cache = true, _root?: Element) {
+export function state<D extends Directive = Directive>() {
   return function (
     target: ClassAccessorDecoratorTarget<D, string | null>,
     context: ClassAccessorDecoratorContext<D, string | null>,


### PR DESCRIPTION
## Description

Introduce the `LitDirective` class for declarative template rendering with lit-html, along with a new `@state` decorator for reactive local state management. Implement a Kiro hook for automated documentation synchronization based on source changes. Enhance the directive lifecycle with batched update methods to improve rendering efficiency. Comprehensive documentation and examples included for all new features.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## یادداشت‌های انتشار

* **ویژگی‌های جدید**
  * افزودن دکوریتور @state برای مدیریت حالت محلی راکتیو
  * معرفی کلاس LitDirective برای ادغام رندرینگ lit-html
  * اضافه شدن چرخه‌ی بروزرسانی دسته‌ای با متدهای requestUpdate_()، update_() و updated_()
  * اضافه شدن هوک جدید "Sync Docs on Source Change" (فعال به‌صورت پیش‌فرض)

* **مستندات**
  * تکمیل README و مرجع API برای Directive، LitDirective و state() با مثال‌های گردش رندرینگ

* **Chores**
  * افزودن وابستگی lit-html
<!-- end of auto-generated comment: release notes by coderabbit.ai -->