### PR TITLE
fix(action-syntax): update regex to allow hyphens in action names

### DIFF
--- a/pkg/nanolib/action/src/delegate.ts
+++ b/pkg/nanolib/action/src/delegate.ts
@@ -75,7 +75,7 @@ import type {Action, ActionRecord} from './type.js';
  *   → actionId='my_submit_handler', payload='$formdata', modifiers={'prevent','validate'}
  * ```
  */
-const syntaxRegex = /^([a-z0-9_:-]+)(?::([^;]+))?(?:;\s*([a-z0-9_,-]+))?$/;
+const syntaxRegex = /^([a-z0-9_-]+)(?::([^;]+))?(?:;\s*([a-z0-9_,-]+))?$/;
 
 // ─── Parsed Action Descriptor ─────────────────────────────────────────────────
 


### PR DESCRIPTION
fix #1798 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## یادداشت‌های انتشار

* **تصحیح خرابی‌ها**
  * بهبود تجزیه شناسه‌های عملکرد: کاراکتر منهای (-) اکنون پشتیبانی می‌شود و کاراکتر دونقطه (:) دیگر مجاز نیست.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->