### PR TITLE
Rename requestUpdate_() to requestUpdate() for public API

### DIFF
--- a/pkg/nanolib/directive/README.md
+++ b/pkg/nanolib/directive/README.md
@@ -178,7 +178,7 @@ new Directive(element, attributeName)
 
 state change (via @state accessor or StateSignal subscription)
   │
-  └─ requestUpdate_()   ← batched, collapses multiple calls into one macrotask
+  └─ requestUpdate()   ← batched, collapses multiple calls into one macrotask
        ├─ update_()     ← DOM mutations / lit-html render() [LitDirective]
        └─ updated_()    ← post-render hook
 ```
@@ -462,7 +462,7 @@ document.addEventListener('form-submitted', (e: CustomEvent) => {
 
 ---
 
-## Reactive Rendering — `requestUpdate_()`, `update_()`, `updated_()`
+## Reactive Rendering — `requestUpdate()`, `update_()`, `updated_()`
 
 `Directive` includes a lightweight batched update cycle for directives that need to re-render their DOM in response to state changes.
 
@@ -471,7 +471,7 @@ document.addEventListener('form-submitted', (e: CustomEvent) => {
 ```
 state change
   │
-  └─ requestUpdate_()     ← schedules one macrotask (multiple calls collapse into one)
+  └─ requestUpdate()     ← schedules one macrotask (multiple calls collapse into one)
        │
        ├─ update_()       ← perform DOM mutations / call lit-html render()
        └─ updated_()      ← post-render hook (focus, measure, dispatch events)
@@ -483,7 +483,7 @@ There are three idiomatic ways to start the cycle:
 
 **1. `@state` accessor (most common — local state)**
 
-Setting a `@state`-decorated accessor automatically calls `requestUpdate_()`:
+Setting a `@state`-decorated accessor automatically calls `requestUpdate()`:
 
 ```ts
 @directive('like-button')
@@ -506,7 +506,7 @@ class LikeButtonDirective extends Directive {
 
 **2. `StateSignal` subscription (shared application state)**
 
-Subscribe to a signal in `init_()` and call `requestUpdate_()` from the callback. Use the built-in `subscribe_()` helper to avoid the manual `addDestroyHook` boilerplate:
+Subscribe to a signal in `init_()` and call `requestUpdate()` from the callback. Use the built-in `subscribe_()` helper to avoid the manual `addDestroyHook` boilerplate:
 
 ```ts
 @directive('cart-badge')
@@ -517,7 +517,7 @@ class CartBadgeDirective extends Directive {
     // subscribe_() automatically unsubscribes on destroy() — no addDestroyHook needed
     this.subscribe_(cartSignal, (cart) => {
       this.count_ = cart.items.length;
-      this.requestUpdate_();
+      this.requestUpdate();
     });
   }
 
@@ -529,13 +529,13 @@ class CartBadgeDirective extends Directive {
 
 **3. Manual call (imperative mutations)**
 
-Call `requestUpdate_()` directly after mutating non-`@state` internal state:
+Call `requestUpdate()` directly after mutating non-`@state` internal state:
 
 ```ts
 protected override init_(): void {
   this.on_('click', () => {
     this.count_++;
-    this.requestUpdate_();
+    this.requestUpdate();
   });
 }
 ```
@@ -573,7 +573,7 @@ export class CartBadgeDirective extends LitDirective {
     // StateSignal.subscribe() calls the callback immediately with the current value,
     // so the first render happens right after init_() without any extra trigger.
     const sub = cartSignal.subscribe((cart) => {
-      this.count_ = String(cart.items.length); // @state setter calls requestUpdate_()
+      this.count_ = String(cart.items.length); // @state setter calls requestUpdate()
     });
     this.addDestroyHook(() => sub.unsubscribe());
   }
@@ -623,7 +623,7 @@ class ShadowCardDirective extends LitDirective {
 
 ## `@state` — Reactive Local State
 
-`@state` marks an `accessor` as reactive. Every time the accessor is set, `requestUpdate_()` is called automatically — no manual trigger needed.
+`@state` marks an `accessor` as reactive. Every time the accessor is set, `requestUpdate()` is called automatically — no manual trigger needed.
 
 ```ts
 @state()
@@ -799,7 +799,7 @@ Class decorator. Registers the decorated class in the global directive registry.
 | `lazyInit_()?`                           | `protected`                                       | Optional — runs once when element first enters the viewport                                                                                                             |
 | `onVisible_()?`                          | `protected`                                       | Optional — runs every time element enters the viewport                                                                                                                  |
 | `onHidden_()?`                           | `protected`                                       | Optional — runs every time element leaves the viewport                                                                                                                  |
-| `requestUpdate_()`                       | `public`                                          | Schedules a batched `update_()` + `updated_()` call for the next macrotask. Multiple calls within the same cycle collapse into one.                                     |
+| `requestUpdate()`                        | `public`                                          | Schedules a batched `update_()` + `updated_()` call for the next macrotask. Multiple calls within the same cycle collapse into one.                                     |
 | `update_()`                              | `protected`                                       | Called once per update cycle — override to perform DOM mutations. `LitDirective` overrides this to call `lit-html`'s `render()`.                                        |
 | `updated_()`                             | `protected`                                       | Called immediately after `update_()` — override for post-render logic (focus, measure, dispatch events).                                                                |
 | `dispatch(event, detail?)`               | `public`                                          | Fires a bubbling `CustomEvent` from `element_`                                                                                                                          |
@@ -816,7 +816,7 @@ Class decorator. Registers the decorated class in the global directive registry.
 | -------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
 | `rootElement_` | `protected HTMLElement \| undefined` | The container `lit-html` renders into. Defaults to `element_`. Override to redirect rendering (e.g. Shadow DOM root). |
 | `render_()`    | `protected abstract`                 | **Must implement.** Returns the `lit-html` template for each update cycle. Keep it pure — no side effects.            |
-| `update_()`    | `protected override`                 | Calls `render_()` and passes the result to `lit-html`'s `render()`. Do not call directly — use `requestUpdate_()`.    |
+| `update_()`    | `protected override`                 | Calls `render_()` and passes the result to `lit-html`'s `render()`. Do not call directly — use `requestUpdate()`.     |
 
 ---
 
@@ -838,7 +838,7 @@ Iterates all live directive instances and calls `autoDestroy()` on each. Removes
 
 ### `state()`
 
-Accessor decorator. Marks the accessor as reactive local state — every `set` call automatically schedules a re-render via `requestUpdate_()`.
+Accessor decorator. Marks the accessor as reactive local state — every `set` call automatically schedules a re-render via `requestUpdate()`.
 
 - No deep-equality check — every assignment schedules an update
 - **Requires `accessor` keyword**

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -424,8 +424,8 @@ export abstract class Directive {
    * already pending are silently ignored.
    *
    * **You rarely need to call this directly.** The two idiomatic triggers are:
-   * - A `@state`-decorated accessor — calls `requestUpdate_()` automatically on every `set`.
-   * - A `StateSignal` subscription — call `requestUpdate_()` inside the callback.
+   * - A `@state`-decorated accessor — calls `requestUpdate()` automatically on every `set`.
+   * - A `StateSignal` subscription — call `requestUpdate()` inside the callback.
    *
    * @example — Triggered automatically by `@state` (most common)
    * ```ts
@@ -436,7 +436,7 @@ export abstract class Directive {
    * @example — Triggered manually from a `StateSignal` subscription
    * ```ts
    * protected override init_(): void {
-   *   const sub = cartSignal.subscribe(() => this.requestUpdate_());
+   *   const sub = cartSignal.subscribe(() => this.requestUpdate());
    *   this.addDestroyHook(() => sub.unsubscribe());
    * }
    * ```
@@ -446,13 +446,13 @@ export abstract class Directive {
    * protected override init_(): void {
    *   this.on_('click', () => {
    *     this.count_++;
-   *     this.requestUpdate_();
+   *     this.requestUpdate();
    *   });
    * }
    * ```
    */
-  public requestUpdate_(): void {
-    this.logger_.logMethod?.('requestUpdate_');
+  public requestUpdate(): void {
+    this.logger_.logMethod?.('requestUpdate');
     if (this.isUpdatePending_) return;
     this.isUpdatePending_ = true;
     delay.nextMacrotask().then(() => {
@@ -472,8 +472,8 @@ export abstract class Directive {
    * The base implementation is a no-op — subclasses such as `LitDirective` override it to call
    * `lit-html`'s `render()`.
    *
-   * This method is always called synchronously within the macrotask scheduled by `requestUpdate_()`.
-   * Do **not** call `requestUpdate_()` from inside `update_()` — it will be ignored because the
+   * This method is always called synchronously within the macrotask scheduled by `requestUpdate()`.
+   * Do **not** call `requestUpdate()` from inside `update_()` — it will be ignored because the
    * pending flag is still set at that point.
    */
   protected update_(): void {

--- a/pkg/nanolib/directive/src/lit-directive.ts
+++ b/pkg/nanolib/directive/src/lit-directive.ts
@@ -13,11 +13,11 @@ import {Directive} from './directive-class.js';
  * A `Directive` subclass that renders its DOM output using `lit-html`.
  *
  * Extend `LitDirective` instead of `Directive` when you want to describe the directive's view
- * as a declarative `lit-html` template. Every time `requestUpdate_()` is called — either
+ * as a declarative `lit-html` template. Every time `requestUpdate()` is called — either
  * manually or automatically by a `@state`-decorated accessor — `update_()` runs, which calls
  * `render_()` and passes the result to `lit-html`'s `render()`.
  *
- * The update cycle is always **batched**: multiple `requestUpdate_()` calls within the same
+ * The update cycle is always **batched**: multiple `requestUpdate()` calls within the same
  * macrotask collapse into a single `render_()` invocation.
  *
  * By default the template is rendered into `this.element_`. Override `rootElement_` to redirect
@@ -30,7 +30,7 @@ import {Directive} from './directive-class.js';
  * ```
  * state change (set @state accessor  OR  signal subscription callback)
  *   │
- *   └─ requestUpdate_()          ← schedules one macrotask (batched)
+ *   └─ requestUpdate()          ← schedules one macrotask (batched)
  *        │
  *        ├─ update_()            ← calls render_() via lit-html render()
  *        └─ updated_()           ← post-render hook (focus, measure, etc.)
@@ -76,7 +76,7 @@ import {Directive} from './directive-class.js';
  *     // cartSignal.subscribe() calls the callback immediately with the current value,
  *     // so the first render happens right after init_() without any extra trigger.
  *     const sub = cartSignal.subscribe((cart) => {
- *       this.count_ = String(cart.items.length); // @state setter calls requestUpdate_()
+ *       this.count_ = String(cart.items.length); // @state setter calls requestUpdate()
  *     });
  *     this.addDestroyHook(() => sub.unsubscribe());
  *   }
@@ -116,8 +116,8 @@ export abstract class LitDirective extends Directive {
   /**
    * Renders the `lit-html` template returned by `render_()` into `rootElement_` (or `element_`).
    *
-   * This method is called automatically by `requestUpdate_()` during each scheduled update cycle.
-   * Do not call it directly — use `requestUpdate_()` instead to ensure batching.
+   * This method is called automatically by `requestUpdate()` during each scheduled update cycle.
+   * Do not call it directly — use `requestUpdate()` instead to ensure batching.
    */
   protected override update_(): void {
     super.update_();

--- a/pkg/nanolib/directive/src/util-decorators.ts
+++ b/pkg/nanolib/directive/src/util-decorators.ts
@@ -135,12 +135,12 @@ export function attribute<D extends Directive = Directive>(name: string, cache =
 /**
  * A property decorator that marks an accessor as reactive local state.
  *
- * When the accessor's value is set, `requestUpdate_()` is called automatically on the directive
+ * When the accessor's value is set, `requestUpdate()` is called automatically on the directive
  * instance, scheduling a batched re-render for the next macrotask.
  *
  * This is the primary way to drive `LitDirective` re-renders from **local** state changes
  * (values owned by the directive itself). For **shared** application state, subscribe to a
- * `StateSignal` inside `init_()` and call `requestUpdate_()` from the subscription callback —
+ * `StateSignal` inside `init_()` and call `requestUpdate()` from the subscription callback —
  * see the signal example below.
  *
  * The decorator is a thin wrapper around the native accessor — it does **not** perform any
@@ -214,7 +214,7 @@ export function state<T, D extends Directive = Directive>() {
       },
       set(this: D, value) {
         target.set.call(this, value);
-        this.requestUpdate_();
+        this.requestUpdate();
       },
     };
   };


### PR DESCRIPTION
## Description

Renamed `requestUpdate_()` to `requestUpdate()` to align with public API naming conventions. This change enhances clarity and consistency in the directive's functionality.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## یادداشت‌های انتشار

* **اسناد**
  * به‌روزرسانی کامل مستندات برای منعکس‌کردن نام‌گذاری جدید روش زمان‌بندی

* **تغییرات API**
  * نام‌گذاری مجدد متد عمومی برنامه‌ریزی دستورالعمل برای وضوح و سهولت استفاده بهتر

<!-- end of auto-generated comment: release notes by coderabbit.ai -->