### PR TITLE
Refactor directive update execution timing

### DIFF
--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -163,6 +163,8 @@ export abstract class Directive {
     delay.nextMacrotask().then(() => this.initializeLifecycle_());
   }
 
+  protected initialized_ = false;
+
   /**
    * Initializes the directive's lifecycle by calling the `init_` method and setting up any necessary observers for lazy initialization and visibility tracking. This method is called after the directive instance is created and the initial attribute value is parsed.
    */
@@ -178,6 +180,11 @@ export abstract class Directive {
     }
     if (this.onVisible_ || this.onHidden_) {
       this.triggerVisibilityObserver_();
+    }
+
+    this.initialized_ = true;
+    if (this.isUpdatePending_) {
+      void this.performUpdate__();
     }
   }
 
@@ -455,14 +462,18 @@ export abstract class Directive {
     this.logger_.logMethod?.('requestUpdate');
     if (this.isUpdatePending_) return;
     this.isUpdatePending_ = true;
-    delay.nextMacrotask().then(() => {
-      try {
-        this.update_();
-      } finally {
-        this.isUpdatePending_ = false;
-      }
-      this.updated_();
-    });
+    void this.performUpdate__();
+  }
+
+  private async performUpdate__(): Promise<void> {
+    await delay.nextMacrotask();
+    if (!this.initialized_) return;
+    try {
+      this.update_();
+    } finally {
+      this.isUpdatePending_ = false;
+    }
+    this.updated_();
   }
 
   /**

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -163,7 +163,7 @@ export abstract class Directive {
     delay.nextMacrotask().then(() => this.initializeLifecycle_());
   }
 
-  protected initialized_ = false;
+  private initialized__ = false;
 
   /**
    * Initializes the directive's lifecycle by calling the `init_` method and setting up any necessary observers for lazy initialization and visibility tracking. This method is called after the directive instance is created and the initial attribute value is parsed.
@@ -182,7 +182,7 @@ export abstract class Directive {
       this.triggerVisibilityObserver_();
     }
 
-    this.initialized_ = true;
+    this.initialized__ = true;
     if (this.isUpdatePending_) {
       void this.performUpdate__();
     }
@@ -461,13 +461,13 @@ export abstract class Directive {
   public requestUpdate(): void {
     this.logger_.logMethod?.('requestUpdate');
     if (this.isUpdatePending_) return;
-    this.isUpdatePending_ = true;
     void this.performUpdate__();
   }
 
   private async performUpdate__(): Promise<void> {
+    this.isUpdatePending_ = true;
     await delay.nextMacrotask();
-    if (!this.initialized_) return;
+    if (this.initialized__ === false || this.isDestroyed()) return;
     try {
       this.update_();
     } finally {


### PR DESCRIPTION
## Description

Defer update execution until the directive's lifecycle is fully initialized. Introduce an `initialized_` flag to track lifecycle completion and extract update logic into a reusable method. This ensures updates occur only after all lifecycle hooks are ready, preventing premature updates.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## یادداشت‌های انتشار

* **بهبود کارایی**
  * بهینه‌سازی مکانیزم به‌روزرسانی داخلی برای کاهش تأخیر و پردازش‌های تکراری.
  * هماهنگ‌سازی بهتر با مرحله‌ی راه‌اندازی تا درخواست‌های به‌روزرسانی قبل از تکمیل آماده‌سازی به‌صورت ایمن اجرا شوند.
  * افزایش پایداری در اجرای چرخه‌های به‌روزرسانی و تضمین پاک‌سازی وضعیت‌های موقتی پس از انجام به‌روزرسانی.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->