### PR TITLE
Add shouldUpdate_ guard method for conditional rendering

### DIFF
--- a/pkg/nanolib/directive/README.md
+++ b/pkg/nanolib/directive/README.md
@@ -179,6 +179,7 @@ new Directive(element, attributeName)
 state change (via @state accessor or StateSignal subscription)
   │
   └─ requestUpdate()   ← batched, collapses multiple calls into one macrotask
+       ├─ shouldUpdate_()?  ← return false to abort (skip update_/updated_ entirely)
        ├─ update_()     ← DOM mutations / lit-html render() [LitDirective]
        └─ updated_()    ← post-render hook
 ```
@@ -462,7 +463,7 @@ document.addEventListener('form-submitted', (e: CustomEvent) => {
 
 ---
 
-## Reactive Rendering — `requestUpdate()`, `update_()`, `updated_()`
+## Reactive Rendering — `requestUpdate()`, `shouldUpdate_()`, `update_()`, `updated_()`
 
 `Directive` includes a lightweight batched update cycle for directives that need to re-render their DOM in response to state changes.
 
@@ -473,8 +474,9 @@ state change
   │
   └─ requestUpdate()     ← schedules one macrotask (multiple calls collapse into one)
        │
-       ├─ update_()       ← perform DOM mutations / call lit-html render()
-       └─ updated_()      ← post-render hook (focus, measure, dispatch events)
+       ├─ shouldUpdate_()?  ← return false to abort (update_/updated_ are skipped)
+       ├─ update_()         ← perform DOM mutations / call lit-html render()
+       └─ updated_()        ← post-render hook (focus, measure, dispatch events)
 ```
 
 ### Triggering an update
@@ -537,6 +539,48 @@ protected override init_(): void {
     this.count_++;
     this.requestUpdate();
   });
+}
+```
+
+### `shouldUpdate_()`
+
+Override to conditionally abort an update cycle before `update_()` runs. Return `false` (strict boolean) to skip the render entirely; return `true` or `void` to proceed normally.
+
+The `isUpdatePending_` flag is cleared even when `shouldUpdate_()` returns `false`, so a future `requestUpdate()` will schedule a new cycle normally.
+
+```ts
+@directive('data-table')
+class DataTableDirective extends LitDirective {
+  private loading_ = true;
+
+  // Suppress all renders until data has been fetched
+  protected override shouldUpdate_(): boolean | void {
+    if (this.loading_) return false;
+  }
+
+  protected override async lazyInit_(): Promise<void> {
+    this.rows_ = await fetchRows();
+    this.loading_ = false;
+    this.requestUpdate(); // shouldUpdate_() now returns void → render proceeds
+  }
+
+  protected override render_() {
+    return html`
+      ${this.rows_.map(
+        (r) => html`
+          <tr><td>${r.name}</td></tr>
+        `,
+      )}
+    `;
+  }
+}
+```
+
+Another common pattern — skip renders while the element is inside a hidden panel:
+
+```ts
+protected override shouldUpdate_(): boolean | void {
+  if (this.element_.closest('[hidden]')) return false;
 }
 ```
 
@@ -633,7 +677,7 @@ accessor count_: string | null = null;
 **Rules:**
 
 - Requires the `accessor` keyword (ES2024 auto-accessor feature)
-- No deep-equality check — every `set` schedules an update, even with the same value
+- **Primitive equality check** — if the new value is identical to the current value (via `Object.is`) and is a primitive or `null`, the update is skipped. For objects and arrays, every `set` schedules an update regardless of reference equality.
 - For **shared** state, use a `StateSignal` subscription instead (see above)
 
 **Combining `@state` with `StateSignal`** is the standard pattern for reactive directives:
@@ -730,6 +774,8 @@ class UserCardDirective extends Directive {
 
 ### `@on(eventType, selector?, options?)`
 
+> **⚠️ Deprecated:** This decorator relies on `context.addInitializer`, which is not yet stable across all JS environments. Use the `on_()` protected method inside `init_()` instead — it provides identical functionality with full stability.
+
 Registers a DOM event listener on `this.element_` (or a matching child element) and automatically removes it when the directive is destroyed — no manual `addEventListener` / `removeEventListener` needed.
 
 ```typescript
@@ -787,36 +833,38 @@ Class decorator. Registers the decorated class in the global directive registry.
 
 ### `Directive` (abstract class)
 
-| Member                                   | Type                                              | Description                                                                                                                                                             |
-| ---------------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `attributeName`                          | `readonly string`                                 | The attribute name this directive is bound to                                                                                                                           |
-| `attributeValue`                         | `readonly string`                                 | The value of the attribute at construction time                                                                                                                         |
-| `index`                                  | `readonly number`                                 | Per-attribute instance counter (0, 1, 2, …)                                                                                                                             |
-| `element_`                               | `protected readonly HTMLElement`                  | The bound DOM element                                                                                                                                                   |
-| `logger_`                                | `protected readonly`                              | Scoped logger: `directive:{attributeName}/{index}`                                                                                                                      |
-| `intersectionOptions_`                   | `protected IntersectionObserverInit \| undefined` | Optional options forwarded to every `IntersectionObserver` created for this directive (`lazyInit_`, `onVisible_`, `onHidden_`). Must be set before `init_()` completes. |
-| `init_()?`                               | `protected`                                       | Optional — runs once after next macrotask (setup, event listeners)                                                                                                      |
-| `lazyInit_()?`                           | `protected`                                       | Optional — runs once when element first enters the viewport                                                                                                             |
-| `onVisible_()?`                          | `protected`                                       | Optional — runs every time element enters the viewport                                                                                                                  |
-| `onHidden_()?`                           | `protected`                                       | Optional — runs every time element leaves the viewport                                                                                                                  |
-| `requestUpdate()`                        | `public`                                          | Schedules a batched `update_()` + `updated_()` call for the next macrotask. Multiple calls within the same cycle collapse into one.                                     |
-| `update_()`                              | `protected`                                       | Called once per update cycle — override to perform DOM mutations. `LitDirective` overrides this to call `lit-html`'s `render()`.                                        |
-| `updated_()`                             | `protected`                                       | Called immediately after `update_()` — override for post-render logic (focus, measure, dispatch events).                                                                |
-| `dispatch(event, detail?)`               | `public`                                          | Fires a bubbling `CustomEvent` from `element_`                                                                                                                          |
-| `addDestroyHook(task)`                   | `public`                                          | Registers an async cleanup callback                                                                                                                                     |
-| `subscribe_(signal, callback, options?)` | `protected`                                       | Subscribes to a read-only signal and automatically unsubscribes on `destroy()`. Idiomatic replacement for `signal.subscribe()` + `addDestroyHook()`.                    |
-| `destroy()`                              | `public async`                                    | Runs all destroy hooks, then nullifies `element_`                                                                                                                       |
-| `autoDestroy()`                          | `public`                                          | Destroys if element is disconnected; returns `true` if destroyed                                                                                                        |
+| Member                                   | Type                                              | Description                                                                                                                                                               |
+| ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attributeName`                          | `readonly string`                                 | The attribute name this directive is bound to                                                                                                                             |
+| `attributeValue`                         | `readonly string`                                 | The value of the attribute at construction time                                                                                                                           |
+| `index`                                  | `readonly number`                                 | Per-attribute instance counter (0, 1, 2, …)                                                                                                                               |
+| `element_`                               | `protected readonly HTMLElement`                  | The bound DOM element                                                                                                                                                     |
+| `logger_`                                | `protected readonly`                              | Scoped logger: `directive:{attributeName}/{index}`                                                                                                                        |
+| `intersectionOptions_`                   | `protected IntersectionObserverInit \| undefined` | Optional options forwarded to every `IntersectionObserver` created for this directive (`lazyInit_`, `onVisible_`, `onHidden_`). Must be set before `init_()` completes.   |
+| `init_()?`                               | `protected`                                       | Optional — runs once after next macrotask (setup, event listeners)                                                                                                        |
+| `lazyInit_()?`                           | `protected`                                       | Optional — runs once when element first enters the viewport                                                                                                               |
+| `onVisible_()?`                          | `protected`                                       | Optional — runs every time element enters the viewport                                                                                                                    |
+| `onHidden_()?`                           | `protected`                                       | Optional — runs every time element leaves the viewport                                                                                                                    |
+| `requestUpdate()`                        | `public`                                          | Schedules a batched `update_()` + `updated_()` call for the next macrotask. Multiple calls within the same cycle collapse into one.                                       |
+| `shouldUpdate_()`                        | `protected`                                       | Called before `update_()` in each cycle. Return `false` to abort the cycle (skips `update_()` and `updated_()`). Return `true` or `void` to proceed. Base returns `void`. |
+| `update_()`                              | `protected`                                       | Called once per update cycle — override to perform DOM mutations. `LitDirective` overrides this to call `lit-html`'s `render()`.                                          |
+| `updated_()`                             | `protected`                                       | Called immediately after `update_()` — override for post-render logic (focus, measure, dispatch events).                                                                  |
+| `dispatch(event, detail?)`               | `public`                                          | Fires a bubbling `CustomEvent` from `element_`                                                                                                                            |
+| `addDestroyHook(task)`                   | `public`                                          | Registers an async cleanup callback                                                                                                                                       |
+| `subscribe_(signal, callback, options?)` | `protected`                                       | Subscribes to a read-only signal and automatically unsubscribes on `destroy()`. Idiomatic replacement for `signal.subscribe()` + `addDestroyHook()`.                      |
+| `destroy()`                              | `public async`                                    | Runs all destroy hooks, then nullifies `element_`                                                                                                                         |
+| `autoDestroy()`                          | `public`                                          | Destroys if element is disconnected; returns `true` if destroyed                                                                                                          |
 
 ---
 
 ### `LitDirective` (abstract class, extends `Directive`)
 
-| Member         | Type                                 | Description                                                                                                           |
-| -------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| `rootElement_` | `protected HTMLElement \| undefined` | The container `lit-html` renders into. Defaults to `element_`. Override to redirect rendering (e.g. Shadow DOM root). |
-| `render_()`    | `protected abstract`                 | **Must implement.** Returns the `lit-html` template for each update cycle. Keep it pure — no side effects.            |
-| `update_()`    | `protected override`                 | Calls `render_()` and passes the result to `lit-html`'s `render()`. Do not call directly — use `requestUpdate()`.     |
+| Member            | Type                                 | Description                                                                                                                                                                    |
+| ----------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `rootElement_`    | `protected HTMLElement \| undefined` | The container `lit-html` renders into. Defaults to `element_`. Override to redirect rendering (e.g. Shadow DOM root).                                                          |
+| `shouldUpdate_()` | `protected override`                 | Inherited guard — return `false` to skip `render_()` entirely for the current cycle. Return `true` or `void` to proceed. Useful for suppressing renders while data is loading. |
+| `render_()`       | `protected abstract`                 | **Must implement.** Returns the `lit-html` template for each update cycle. Keep it pure — no side effects.                                                                     |
+| `update_()`       | `protected override`                 | Calls `render_()` and passes the result to `lit-html`'s `render()`. Do not call directly — use `requestUpdate()`.                                                              |
 
 ---
 
@@ -840,7 +888,7 @@ Iterates all live directive instances and calls `autoDestroy()` on each. Removes
 
 Accessor decorator. Marks the accessor as reactive local state — every `set` call automatically schedules a re-render via `requestUpdate()`.
 
-- No deep-equality check — every assignment schedules an update
+- **Primitive equality check** — if the new value is identical to the current value (via `Object.is`) and is a primitive or `null`, the update is skipped. For objects and arrays, every `set` schedules an update regardless of reference equality.
 - **Requires `accessor` keyword**
 - For shared application state, use a `StateSignal` subscription instead
 
@@ -875,7 +923,9 @@ Accessor decorator. Lazily reads `element_.getAttribute(name)`.
 
 ---
 
-### `on(eventType, selector?, options?)`
+### `on(eventType, selector?, options?)` _(deprecated)_
+
+> **⚠️ Deprecated:** Relies on `context.addInitializer`, which is not yet stable. Use `on_()` inside `init_()` instead.
 
 Method decorator. Registers a DOM event listener and removes it automatically on `destroy()`.
 

--- a/pkg/nanolib/directive/README.md
+++ b/pkg/nanolib/directive/README.md
@@ -178,7 +178,7 @@ new Directive(element, attributeName)
 
 state change (via @state accessor or StateSignal subscription)
   │
-  └─ requestUpdate()   ← batched, collapses multiple calls into one macrotask
+  └─ requestUpdate()   ← ignored if disableUpdate_ is true; batched otherwise
        ├─ shouldUpdate_()?  ← return false to abort (skip update_/updated_ entirely)
        ├─ update_()     ← DOM mutations / lit-html render() [LitDirective]
        └─ updated_()    ← post-render hook
@@ -472,7 +472,7 @@ document.addEventListener('form-submitted', (e: CustomEvent) => {
 ```
 state change
   │
-  └─ requestUpdate()     ← schedules one macrotask (multiple calls collapse into one)
+  └─ requestUpdate()     ← ignored if disableUpdate_ is true; batched otherwise
        │
        ├─ shouldUpdate_()?  ← return false to abort (update_/updated_ are skipped)
        ├─ update_()         ← perform DOM mutations / call lit-html render()
@@ -546,7 +546,7 @@ protected override init_(): void {
 
 Override to conditionally abort an update cycle before `update_()` runs. Return `false` (strict boolean) to skip the render entirely; return `true` or `void` to proceed normally.
 
-The `isUpdatePending_` flag is cleared even when `shouldUpdate_()` returns `false`, so a future `requestUpdate()` will schedule a new cycle normally.
+The `disableUpdate_` flag is cleared even when `shouldUpdate_()` returns `false`, so a future `requestUpdate()` will schedule a new cycle normally.
 
 ```ts
 @directive('data-table')
@@ -581,6 +581,71 @@ Another common pattern — skip renders while the element is inside a hidden pan
 ```ts
 protected override shouldUpdate_(): boolean | void {
   if (this.element_.closest('[hidden]')) return false;
+}
+```
+
+### `disableUpdate_`
+
+A `protected` boolean flag that controls whether `requestUpdate()` is allowed to schedule a new render cycle. It serves two roles:
+
+**1. Pending-update guard (automatic)**
+Set to `true` by `requestUpdate()` and cleared back to `false` by `performUpdate__()` once the cycle finishes (or is aborted by `shouldUpdate_()`). This collapses multiple `requestUpdate()` calls within the same macrotask into a single render.
+
+**2. Manual render suppression (opt-in)**
+Subclasses can set `disableUpdate_ = true` at any time to pause rendering indefinitely — for example, while performing a multi-step async setup or while the element is off-screen. Set it back to `false` and call `requestUpdate()` to resume.
+
+**`disableUpdate_` vs `shouldUpdate_()`**
+
+|                      | `disableUpdate_ = true`                    | `shouldUpdate_()` returning `false`         |
+| -------------------- | ------------------------------------------ | ------------------------------------------- |
+| Scope                | Prevents **all future** cycles until reset | Aborts only the **current** in-flight cycle |
+| Resets automatically | No — you must reset it manually            | Yes — cleared after each aborted cycle      |
+| Use when             | Sustained pause (loading, off-screen)      | Per-cycle condition (data not ready yet)    |
+
+```ts
+@directive('live-feed')
+class LiveFeedDirective extends LitDirective {
+  // Pause all renders while the element is scrolled out of view
+  protected override onHidden_(): void {
+    this.disableUpdate_ = true;
+  }
+
+  protected override onVisible_(): void {
+    this.disableUpdate_ = false;
+    this.requestUpdate(); // catch up with any missed state changes
+  }
+
+  protected override render_() {
+    return html`
+      <ul>
+        ${this.items_.map(
+          (i) => html`
+            <li>${i}</li>
+          `,
+        )}
+      </ul>
+    `;
+  }
+}
+```
+
+```ts
+@directive('async-card')
+class AsyncCardDirective extends LitDirective {
+  protected override async init_(): Promise<void> {
+    // Block signal-triggered renders until initial data is ready
+    this.disableUpdate_ = true;
+
+    this.subscribe_(dataSignal, (data) => {
+      this.data_ = data;
+      this.requestUpdate(); // silently ignored while disableUpdate_ is true
+    });
+
+    await this.loadInitialData_();
+
+    this.disableUpdate_ = false; // re-enable
+    this.requestUpdate(); // first render with fully loaded state
+  }
 }
 ```
 
@@ -833,27 +898,28 @@ Class decorator. Registers the decorated class in the global directive registry.
 
 ### `Directive` (abstract class)
 
-| Member                                   | Type                                              | Description                                                                                                                                                               |
-| ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `attributeName`                          | `readonly string`                                 | The attribute name this directive is bound to                                                                                                                             |
-| `attributeValue`                         | `readonly string`                                 | The value of the attribute at construction time                                                                                                                           |
-| `index`                                  | `readonly number`                                 | Per-attribute instance counter (0, 1, 2, …)                                                                                                                               |
-| `element_`                               | `protected readonly HTMLElement`                  | The bound DOM element                                                                                                                                                     |
-| `logger_`                                | `protected readonly`                              | Scoped logger: `directive:{attributeName}/{index}`                                                                                                                        |
-| `intersectionOptions_`                   | `protected IntersectionObserverInit \| undefined` | Optional options forwarded to every `IntersectionObserver` created for this directive (`lazyInit_`, `onVisible_`, `onHidden_`). Must be set before `init_()` completes.   |
-| `init_()?`                               | `protected`                                       | Optional — runs once after next macrotask (setup, event listeners)                                                                                                        |
-| `lazyInit_()?`                           | `protected`                                       | Optional — runs once when element first enters the viewport                                                                                                               |
-| `onVisible_()?`                          | `protected`                                       | Optional — runs every time element enters the viewport                                                                                                                    |
-| `onHidden_()?`                           | `protected`                                       | Optional — runs every time element leaves the viewport                                                                                                                    |
-| `requestUpdate()`                        | `public`                                          | Schedules a batched `update_()` + `updated_()` call for the next macrotask. Multiple calls within the same cycle collapse into one.                                       |
-| `shouldUpdate_()`                        | `protected`                                       | Called before `update_()` in each cycle. Return `false` to abort the cycle (skips `update_()` and `updated_()`). Return `true` or `void` to proceed. Base returns `void`. |
-| `update_()`                              | `protected`                                       | Called once per update cycle — override to perform DOM mutations. `LitDirective` overrides this to call `lit-html`'s `render()`.                                          |
-| `updated_()`                             | `protected`                                       | Called immediately after `update_()` — override for post-render logic (focus, measure, dispatch events).                                                                  |
-| `dispatch(event, detail?)`               | `public`                                          | Fires a bubbling `CustomEvent` from `element_`                                                                                                                            |
-| `addDestroyHook(task)`                   | `public`                                          | Registers an async cleanup callback                                                                                                                                       |
-| `subscribe_(signal, callback, options?)` | `protected`                                       | Subscribes to a read-only signal and automatically unsubscribes on `destroy()`. Idiomatic replacement for `signal.subscribe()` + `addDestroyHook()`.                      |
-| `destroy()`                              | `public async`                                    | Runs all destroy hooks, then nullifies `element_`                                                                                                                         |
-| `autoDestroy()`                          | `public`                                          | Destroys if element is disconnected; returns `true` if destroyed                                                                                                          |
+| Member                                   | Type                                              | Description                                                                                                                                                                          |
+| ---------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `attributeName`                          | `readonly string`                                 | The attribute name this directive is bound to                                                                                                                                        |
+| `attributeValue`                         | `readonly string`                                 | The value of the attribute at construction time                                                                                                                                      |
+| `index`                                  | `readonly number`                                 | Per-attribute instance counter (0, 1, 2, …)                                                                                                                                          |
+| `element_`                               | `protected readonly HTMLElement`                  | The bound DOM element                                                                                                                                                                |
+| `logger_`                                | `protected readonly`                              | Scoped logger: `directive:{attributeName}/{index}`                                                                                                                                   |
+| `intersectionOptions_`                   | `protected IntersectionObserverInit \| undefined` | Optional options forwarded to every `IntersectionObserver` created for this directive (`lazyInit_`, `onVisible_`, `onHidden_`). Must be set before `init_()` completes.              |
+| `init_()?`                               | `protected`                                       | Optional — runs once after next macrotask (setup, event listeners)                                                                                                                   |
+| `lazyInit_()?`                           | `protected`                                       | Optional — runs once when element first enters the viewport                                                                                                                          |
+| `onVisible_()?`                          | `protected`                                       | Optional — runs every time element enters the viewport                                                                                                                               |
+| `onHidden_()?`                           | `protected`                                       | Optional — runs every time element leaves the viewport                                                                                                                               |
+| `requestUpdate()`                        | `public`                                          | Schedules a batched `update_()` + `updated_()` call for the next macrotask. Ignored if `disableUpdate_` is `true`. Multiple calls within the same cycle collapse into one.           |
+| `disableUpdate_`                         | `protected boolean`                               | When `true`, `requestUpdate()` is a no-op. Set manually to pause rendering; reset to `false` and call `requestUpdate()` to resume. Also used internally as the pending-update guard. |
+| `shouldUpdate_()`                        | `protected`                                       | Called before `update_()` in each cycle. Return `false` to abort the cycle (skips `update_()` and `updated_()`). Return `true` or `void` to proceed. Base returns `void`.            |
+| `update_()`                              | `protected`                                       | Called once per update cycle — override to perform DOM mutations. `LitDirective` overrides this to call `lit-html`'s `render()`.                                                     |
+| `updated_()`                             | `protected`                                       | Called immediately after `update_()` — override for post-render logic (focus, measure, dispatch events).                                                                             |
+| `dispatch(event, detail?)`               | `public`                                          | Fires a bubbling `CustomEvent` from `element_`                                                                                                                                       |
+| `addDestroyHook(task)`                   | `public`                                          | Registers an async cleanup callback                                                                                                                                                  |
+| `subscribe_(signal, callback, options?)` | `protected`                                       | Subscribes to a read-only signal and automatically unsubscribes on `destroy()`. Idiomatic replacement for `signal.subscribe()` + `addDestroyHook()`.                                 |
+| `destroy()`                              | `public async`                                    | Runs all destroy hooks, then nullifies `element_`                                                                                                                                    |
+| `autoDestroy()`                          | `public`                                          | Destroys if element is disconnected; returns `true` if destroyed                                                                                                                     |
 
 ---
 

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -464,9 +464,15 @@ export abstract class Directive {
     void this.performUpdate__();
   }
 
+  /**
+   * Performs the update cycle by calling `update_()` and then `updated_()`.
+   * This method is responsible for executing the update logic in a batched manner, ensuring that multiple calls to `requestUpdate()` within the same macrotask result in only one execution of `update_()` and `updated_()`.
+   */
   private async performUpdate__(): Promise<void> {
     this.isUpdatePending_ = true;
     await delay.nextMacrotask();
+    this.logger_.logMethod?.('performUpdate__');
+    if (this.shouldUpdate_() === false) return;
     if (this.initialized__ === false || this.isDestroyed()) return;
     try {
       this.update_();
@@ -475,6 +481,62 @@ export abstract class Directive {
     }
     this.updated_();
   }
+
+  /**
+   * Guards the update cycle — called by `performUpdate__()` just before `update_()` runs.
+   *
+   * Override this method to implement conditional rendering logic. The return value controls
+   * whether the current update cycle proceeds:
+   *
+   * - Return `false` (strict boolean) → cycle is **aborted**: `update_()` and `updated_()` are
+   *   **not** called. The `isUpdatePending_` flag is also cleared, so a future `requestUpdate()`
+   *   will schedule a new cycle normally.
+   * - Return `true`, `undefined`, or `void` → cycle **proceeds** as normal.
+   *
+   * The base implementation returns `void` (i.e., always proceeds).
+   *
+   * **Placement in the update cycle:**
+   * ```
+   * requestUpdate()
+   *   └─ (next macrotask)
+   *        ├─ shouldUpdate_()   ← return false to abort here
+   *        ├─ update_()         ← DOM mutations / lit-html render()
+   *        └─ updated_()        ← post-render hook
+   * ```
+   *
+   * @returns `false` to abort the cycle, or `true` / `void` to allow it.
+   *
+   * @example — Skip render while a loading flag is set
+   * ```ts
+   * @directive('data-table')
+   * class DataTableDirective extends LitDirective {
+   *   private loading_ = true;
+   *
+   *   protected override shouldUpdate_(): boolean | void {
+   *     // Do not render until data has been fetched
+   *     if (this.loading_) return false;
+   *   }
+   *
+   *   protected override async lazyInit_(): Promise<void> {
+   *     this.rows_ = await fetchRows();
+   *     this.loading_ = false;
+   *     this.requestUpdate();
+   *   }
+   *
+   *   protected override render_() {
+   *     return html`${this.rows_.map((r) => html`<tr><td>${r.name}</td></tr>`)}`;
+   *   }
+   * }
+   * ```
+   *
+   * @example — Abort update when the element is hidden (e.g. inside an inactive tab)
+   * ```ts
+   * protected override shouldUpdate_(): boolean | void {
+   *   if (this.element_.closest('[hidden]')) return false;
+   * }
+   * ```
+   */
+  protected shouldUpdate_(): boolean | void {}
 
   /**
    * Called during each scheduled update cycle, immediately before `updated_()`.

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -183,7 +183,7 @@ export abstract class Directive {
     }
 
     this.initialized__ = true;
-    if (this.isUpdatePending_) {
+    if (this.disableUpdate_) {
       void this.performUpdate__();
     }
   }
@@ -409,7 +409,7 @@ export abstract class Directive {
     options?: AddEventListenerOptions | boolean,
   ): void {
     if (typeof element === 'string') {
-      element = this.element_.querySelector(element);
+      element = this.element_.querySelector<HTMLElement>(element);
     }
     if (element == null) {
       this.logger_.accident('on', 'target_not_found', {target: element});
@@ -421,7 +421,56 @@ export abstract class Directive {
     this.addDestroyHook(() => element.removeEventListener(eventType, boundListener as EventListener, options));
   }
 
-  private isUpdatePending_ = false;
+  /**
+   * Controls whether `requestUpdate()` is allowed to schedule a new render cycle.
+   *
+   * This flag serves two purposes simultaneously:
+   *
+   * 1. **Pending-update guard** — set to `true` by `requestUpdate()` and cleared to `false`
+   *    by `performUpdate__()` once the cycle completes (or is aborted by `shouldUpdate_()`).
+   *    This collapses multiple `requestUpdate()` calls within the same macrotask into a single
+   *    render, preventing redundant work.
+   *
+   * 2. **Manual render suppression** — subclasses may set this to `true` at any time to
+   *    permanently pause rendering (e.g. while the directive is in a loading or suspended state).
+   *    Set it back to `false` and call `requestUpdate()` to resume.
+   *
+   * **Interaction with `shouldUpdate_()`:**
+   * `shouldUpdate_()` aborts a single in-flight cycle without preventing future ones.
+   * `disableUpdate_ = true` prevents any cycle from being scheduled at all until it is reset.
+   * Use `shouldUpdate_()` for per-cycle conditions; use `disableUpdate_` for sustained pauses.
+   *
+   * @example — Pause rendering during a multi-step async operation
+   * ```ts
+   * protected override async init_(): Promise<void> {
+   *   // Prevent any signal-triggered renders while we are still setting up
+   *   this.disableUpdate_ = true;
+   *
+   *   this.subscribe_(userSignal, (user) => {
+   *     this.user_ = user;
+   *     this.requestUpdate(); // silently ignored while disableUpdate_ is true
+   *   });
+   *
+   *   await this.loadInitialData_();
+   *
+   *   this.disableUpdate_ = false; // re-enable rendering
+   *   this.requestUpdate();        // trigger the first render with fully loaded state
+   * }
+   * ```
+   *
+   * @example — Suspend rendering when the directive enters a background tab
+   * ```ts
+   * protected override onHidden_(): void {
+   *   this.disableUpdate_ = true; // no renders while off-screen
+   * }
+   *
+   * protected override onVisible_(): void {
+   *   this.disableUpdate_ = false;
+   *   this.requestUpdate(); // catch up with any missed state changes
+   * }
+   * ```
+   */
+  protected disableUpdate_ = false;
 
   /**
    * Schedules a batched re-render for the next macrotask.
@@ -460,7 +509,8 @@ export abstract class Directive {
    */
   public requestUpdate(): void {
     this.logger_.logMethod?.('requestUpdate');
-    if (this.isUpdatePending_) return;
+    if (this.disableUpdate_) return;
+    this.disableUpdate_ = true;
     void this.performUpdate__();
   }
 
@@ -469,18 +519,17 @@ export abstract class Directive {
    * This method is responsible for executing the update logic in a batched manner, ensuring that multiple calls to `requestUpdate()` within the same macrotask result in only one execution of `update_()` and `updated_()`.
    */
   private async performUpdate__(): Promise<void> {
-    this.isUpdatePending_ = true;
     await delay.nextMacrotask();
     this.logger_.logMethod?.('performUpdate__');
     if (this.shouldUpdate_() === false) {
-      this.isUpdatePending_ = true;
+      this.disableUpdate_ = false;
       return;
     }
     if (this.initialized__ === false || this.isDestroyed()) return;
     try {
       this.update_();
     } finally {
-      this.isUpdatePending_ = false;
+      this.disableUpdate_ = false;
     }
     this.updated_();
   }
@@ -492,7 +541,7 @@ export abstract class Directive {
    * whether the current update cycle proceeds:
    *
    * - Return `false` (strict boolean) → cycle is **aborted**: `update_()` and `updated_()` are
-   *   **not** called. The `isUpdatePending_` flag is also cleared, so a future `requestUpdate()`
+   *   **not** called. The `disableUpdate_` flag is also cleared, so a future `requestUpdate()`
    *   will schedule a new cycle normally.
    * - Return `true`, `undefined`, or `void` → cycle **proceeds** as normal.
    *

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -472,7 +472,10 @@ export abstract class Directive {
     this.isUpdatePending_ = true;
     await delay.nextMacrotask();
     this.logger_.logMethod?.('performUpdate__');
-    if (this.shouldUpdate_() === false) return;
+    if (this.shouldUpdate_() === false) {
+      this.isUpdatePending_ = true;
+      return;
+    }
     if (this.initialized__ === false || this.isDestroyed()) return;
     try {
       this.update_();

--- a/pkg/nanolib/directive/src/lit-directive.ts
+++ b/pkg/nanolib/directive/src/lit-directive.ts
@@ -32,9 +32,14 @@ import {Directive} from './directive-class.js';
  *   │
  *   └─ requestUpdate()          ← schedules one macrotask (batched)
  *        │
- *        ├─ update_()            ← calls render_() via lit-html render()
- *        └─ updated_()           ← post-render hook (focus, measure, etc.)
+ *        ├─ shouldUpdate_()?    ← return false to abort (skip render entirely)
+ *        ├─ update_()           ← calls render_() via lit-html render()
+ *        └─ updated_()          ← post-render hook (focus, measure, etc.)
  * ```
+ *
+ * Override `shouldUpdate_()` to conditionally skip a render — for example, while data is still
+ * loading or while the element is inside a hidden panel. Return `false` to abort; return `true`
+ * or `void` to proceed normally.
  *
  * ---
  *
@@ -141,4 +146,52 @@ export abstract class LitDirective extends Directive {
    * ```
    */
   protected abstract render_(): unknown;
+
+  /**
+   * Guards the render cycle for `LitDirective`.
+   *
+   * Inherited from `Directive`. Override to skip a `render_()` call when the current state does
+   * not warrant a DOM update — for example, while data is still loading or while the element is
+   * inside a hidden panel.
+   *
+   * Return `false` to abort the cycle (`render_()`, `update_()`, and `updated_()` are **not**
+   * called). Return `true` or `void` to proceed normally.
+   *
+   * **Placement in the update cycle:**
+   * ```
+   * requestUpdate()
+   *   └─ (next macrotask)
+   *        ├─ shouldUpdate_()   ← return false to skip render_() entirely
+   *        ├─ update_()         ← calls render_() via lit-html render()
+   *        └─ updated_()        ← post-render hook
+   * ```
+   *
+   * @returns `false` to abort the render cycle, or `true` / `void` to allow it.
+   *
+   * @example — Suppress renders while data is loading
+   * ```ts
+   * @directive('product-list')
+   * class ProductListDirective extends LitDirective {
+   *   private products_: Product[] = [];
+   *   private loading_ = true;
+   *
+   *   protected override shouldUpdate_(): boolean | void {
+   *     if (this.loading_) return false; // render_() will not be called
+   *   }
+   *
+   *   protected override async lazyInit_(): Promise<void> {
+   *     this.products_ = await fetchProducts();
+   *     this.loading_ = false;
+   *     this.requestUpdate(); // now shouldUpdate_() returns void → render proceeds
+   *   }
+   *
+   *   protected override render_() {
+   *     return html`${this.products_.map((p) => html`<li>${p.name}</li>`)}`;
+   *   }
+   * }
+   * ```
+   */
+  protected override shouldUpdate_(): boolean | void {
+    return super.shouldUpdate_();
+  }
 }

--- a/pkg/nanolib/directive/src/util-decorators.ts
+++ b/pkg/nanolib/directive/src/util-decorators.ts
@@ -143,8 +143,10 @@ export function attribute<D extends Directive = Directive>(name: string, cache =
  * `StateSignal` inside `init_()` and call `requestUpdate()` from the subscription callback —
  * see the signal example below.
  *
- * The decorator is a thin wrapper around the native accessor — it does **not** perform any
- * deep-equality check. Every `set` call (even with the same value) will schedule an update.
+ * The decorator performs a **shallow equality check for primitives**: if the new value is
+ * identical to the current value (via `Object.is`) and is a primitive (or `null`), the update
+ * is skipped. For object and array values no equality check is performed — every `set` call
+ * schedules an update regardless of whether the reference changed.
  *
  * @remarks
  * The `name`, `cache`, and `root` parameters are accepted for API symmetry with `@attribute`
@@ -212,8 +214,13 @@ export function state<T, D extends Directive = Directive>() {
       get(this: D) {
         return target.get.call(this);
       },
-      set(this: D, value) {
-        target.set.call(this, value);
+      set(this: D, newValue) {
+        const oldValue = target.get.call(this);
+        // For primitives (including null), do not notify if the value is the same.
+        if (Object.is(oldValue, newValue) && (typeof newValue !== 'object' || newValue === null)) {
+          return;
+        }
+        target.set.call(this, newValue);
         this.requestUpdate();
       },
     };


### PR DESCRIPTION
## Description

Add a `shouldUpdate_()` method to control the update cycle in `LitDirective`, allowing for conditional rendering based on various criteria such as loading state or visibility. Introduce a shallow equality check in the state decorator to prevent unnecessary updates for unchanged primitive values. Update documentation to clarify the behavior of the new guard method and the state decorator. This enhances performance by reducing redundant render cycles.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## یادداشت‌های انتشار

* **ویژگی‌های جدید**
  * اضافه‌شدن قلاب تصمیم‌گیرنده پیش از چرخهٔ به‌روزرسانی برای امکان جلوگیری از اجرای کامل چرخه
  * بهینه‌سازی رفتار @state: جلوگیری از به‌روزرسانی وقتی مقدار جدیدِ ابتدایی یا null با قبلی برابر باشد

* **استهلاک**
  * دکوریتور @on() منسوخ اعلام شد؛ از روش جایگزین داخل مقداردهی اولیه استفاده کنید
<!-- end of auto-generated comment: release notes by coderabbit.ai -->