### PR TITLE
Update StateSignal subscription behavior and fix immediate callbacks

### DIFF
--- a/pkg/nanolib/signal/src/core/state-signal.test.js
+++ b/pkg/nanolib/signal/src/core/state-signal.test.js
@@ -40,8 +40,8 @@ describe('StateSignal', () => {
     const callback = jest.fn();
     const newValue = 42;
 
-    signal.subscribe(callback);
     signal.set(newValue);
+    signal.subscribe(callback);
     await delay.nextMacrotask();
     expect(callback).toHaveBeenCalledWith(newValue);
     expect(callback).toHaveBeenCalledTimes(1);

--- a/pkg/nanolib/signal/src/core/state-signal.test.js
+++ b/pkg/nanolib/signal/src/core/state-signal.test.js
@@ -50,8 +50,8 @@ describe('StateSignal', () => {
   it('should not notify multiple times', async () => {
     const callback = jest.fn();
 
-    signal.subscribe(callback);
     signal.set(1);
+    signal.subscribe(callback);
     signal.set(2);
     signal.set(3);
     signal.set(4);

--- a/pkg/nanolib/signal/src/core/state-signal.ts
+++ b/pkg/nanolib/signal/src/core/state-signal.ts
@@ -181,7 +181,6 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
       .then((): void => {
         this.logger_.logStep?.('subscribe', 'immediate_callback');
         if (this.notifyVersion__ !== subscribeVersion) return; // A notification occurred after subscribing, so skip the immediate callback.
-        if (this.notifyPending__) return; // A notification is already pending, so the callback will be called with the latest value when the notification is processed.
         if (options.once) {
           result.unsubscribe();
         }

--- a/pkg/nanolib/signal/src/core/state-signal.ts
+++ b/pkg/nanolib/signal/src/core/state-signal.ts
@@ -51,6 +51,18 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
    */
   protected logger_: AlwatrLogger;
 
+  /**
+   * Indicates if a notification is already scheduled.
+   * @private
+   */
+  private notifyPending__ = false;
+
+  /**
+   * The version of the last notification.
+   * @private
+   */
+  private notifyVersion__ = 0;
+
   constructor(config: StateSignalConfig<T>) {
     super({
       name: config.name,
@@ -103,12 +115,6 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
   }
 
   /**
-   * Indicates if a notification is already scheduled.
-   * @private
-   */
-  private notifyPending__ = false;
-
-  /**
    * Notifies all listeners about the current value, even if it hasn't changed.
    *
    * This method is useful when you change the value instance directly (e.g., mutating an object) and want to inform listeners about the change.
@@ -117,6 +123,7 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
     this.logger_.logMethod?.('notifyChange');
     this.checkDestroyed_();
 
+    this.notifyVersion__++;
     if (this.notifyPending__) return;
     this.notifyPending__ = true;
 
@@ -165,23 +172,22 @@ export class StateSignal<T> extends SignalBase<T> implements IReadonlySignal<T> 
 
     const result = super.subscribe(callback, options);
 
-    // By default, new subscribers to a StateSignal should receive the current value.
-    if (options.receivePrevious !== false) {
-      // Immediately (but asynchronously) call the listener with the current value.
-      // This is done in a microtask to ensure it happens after the subscription is fully registered.
-      delay
-        .nextMicrotask()
-        .then(() => {
-          this.logger_.logStep?.('subscribe', 'immediate_callback');
-          if (!this.notifyPending__) {
-            callback(this.value__);
-            if (options.once) {
-              result.unsubscribe();
-            }
-          }
-        })
-        .catch((err) => this.logger_.error('subscribe', 'immediate_callback_failed', err));
-    }
+    if (options.receivePrevious === false) return result; // If the subscriber opts out of receiving the current value, skip the immediate callback.
+    if (this.notifyPending__) return result; // If a notification is already pending, the callback will be called with the latest value when the notification is processed.
+
+    const subscribeVersion = this.notifyVersion__;
+    delay
+      .nextMicrotask()
+      .then((): void => {
+        this.logger_.logStep?.('subscribe', 'immediate_callback');
+        if (this.notifyVersion__ !== subscribeVersion) return; // A notification occurred after subscribing, so skip the immediate callback.
+        if (this.notifyPending__) return; // A notification is already pending, so the callback will be called with the latest value when the notification is processed.
+        if (options.once) {
+          result.unsubscribe();
+        }
+        callback(this.value__);
+      })
+      .catch((err) => this.logger_.error('subscribe', 'immediate_callback_failed', err));
 
     return result;
   }


### PR DESCRIPTION
## Description

Improved the subscription order in StateSignal tests to ensure callbacks receive the correct initial value. Enhanced the StateSignal implementation to track notification versions, preventing stale immediate callbacks and ensuring accurate notification behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# یادداشت‌های انتشار

* **رفع اشکالات**
  * بهبود مکانیزم هماهنگی اعلان‌ها برای جلوگیری از فراخوانی‌های اضافی/تکراری هنگام اشتراک‌گذاری یا به‌روزرسانی سریع مقدار.
  * بهبود پایداری رفتار اعلان فوری برای مشترکینی که مقدار قبلی را دریافت می‌کنند.

* **آزمایش‌ها**
  * به‌روزرسانی تست‌ها برای اعتبارسنجی ترتیب جدید عملیات اشتراک و تنظیم مقدار.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->