### PR TITLE
Refactor signal interfaces for improved type safety

### DIFF
--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -9,7 +9,7 @@ import type {Awaitable} from '@alwatr/type-helper';
 import {delay} from '@alwatr/delay';
 import {createLogger} from '@alwatr/logger';
 import {finalizationRegistry} from './lib.js';
-import type {IReadonlySignal, ListenerCallback, SubscribeOptions} from '@alwatr/signal';
+import type {ISignal, ListenerCallback, SubscribeOptions} from '@alwatr/signal';
 
 /**
  * A map to keep track of the number of instances for each directive name. This helps in generating unique indices for directives when multiple instances are present on the same page.
@@ -649,7 +649,7 @@ export abstract class Directive {
    * }
    * ```
    */
-  protected subscribe_<T>(signal: IReadonlySignal<T>, callback: ListenerCallback<T>, options?: SubscribeOptions): void {
+  protected subscribe_<T>(signal: ISignal<T>, callback: ListenerCallback<T>, options?: SubscribeOptions): void {
     this.addDestroyHook(signal.subscribe(callback, options).unsubscribe);
   }
 }

--- a/pkg/nanolib/directive/src/directive-class.ts
+++ b/pkg/nanolib/directive/src/directive-class.ts
@@ -9,7 +9,7 @@ import type {Awaitable} from '@alwatr/type-helper';
 import {delay} from '@alwatr/delay';
 import {createLogger} from '@alwatr/logger';
 import {finalizationRegistry} from './lib.js';
-import type {ISignal, ListenerCallback, SubscribeOptions} from '@alwatr/signal';
+import type {IBaseSignal, ListenerCallback, SubscribeOptions} from '@alwatr/signal';
 
 /**
  * A map to keep track of the number of instances for each directive name. This helps in generating unique indices for directives when multiple instances are present on the same page.
@@ -649,7 +649,7 @@ export abstract class Directive {
    * }
    * ```
    */
-  protected subscribe_<T>(signal: ISignal<T>, callback: ListenerCallback<T>, options?: SubscribeOptions): void {
+  protected subscribe_<T>(signal: IBaseSignal<T>, callback: ListenerCallback<T>, options?: SubscribeOptions): void {
     this.addDestroyHook(signal.subscribe(callback, options).unsubscribe);
   }
 }

--- a/pkg/nanolib/signal/src/core/event-signal.ts
+++ b/pkg/nanolib/signal/src/core/event-signal.ts
@@ -3,7 +3,7 @@ import {createLogger, type AlwatrLogger} from '@alwatr/logger';
 
 import {SignalBase} from './signal-base.js';
 
-import type {ISignal, SignalConfig} from '../type.js';
+import type {IBaseSignal, SignalConfig} from '../type.js';
 
 /**
  * A stateless signal for dispatching transient events.
@@ -32,7 +32,7 @@ import type {ISignal, SignalConfig} from '../type.js';
  * onAppReady.subscribe(() => console.log('Application is ready!'));
  * onAppReady.dispatch(); // Notifies the listener.
  */
-export class EventSignal<T = void> extends SignalBase<T> implements ISignal<T> {
+export class EventSignal<T = void> extends SignalBase<T> implements IBaseSignal<T> {
   /**
    * The logger instance for this signal.
    * @protected

--- a/pkg/nanolib/signal/src/core/event-signal.ts
+++ b/pkg/nanolib/signal/src/core/event-signal.ts
@@ -1,9 +1,9 @@
-import { delay } from '@alwatr/delay';
-import { createLogger, type AlwatrLogger } from '@alwatr/logger';
+import {delay} from '@alwatr/delay';
+import {createLogger, type AlwatrLogger} from '@alwatr/logger';
 
-import { SignalBase } from './signal-base.js';
+import {SignalBase} from './signal-base.js';
 
-import type { SignalConfig } from '../type.js';
+import type {ISignal, SignalConfig} from '../type.js';
 
 /**
  * A stateless signal for dispatching transient events.
@@ -32,7 +32,7 @@ import type { SignalConfig } from '../type.js';
  * onAppReady.subscribe(() => console.log('Application is ready!'));
  * onAppReady.dispatch(); // Notifies the listener.
  */
-export class EventSignal<T = void> extends SignalBase<T> {
+export class EventSignal<T = void> extends SignalBase<T> implements ISignal<T> {
   /**
    * The logger instance for this signal.
    * @protected
@@ -53,7 +53,7 @@ export class EventSignal<T = void> extends SignalBase<T> {
    * @param payload The data to send with the event.
    */
   public dispatch(payload: T): void {
-    this.logger_.logMethodArgs?.('dispatch', { payload });
+    this.logger_.logMethodArgs?.('dispatch', {payload});
     this.checkDestroyed_();
     // Dispatch as a microtask to ensure consistent, non-blocking behavior.
     delay.nextMicrotask().then(() => this.notify_(payload));

--- a/pkg/nanolib/signal/src/type.ts
+++ b/pkg/nanolib/signal/src/type.ts
@@ -125,22 +125,17 @@ export interface StateSignalConfig<T> extends SignalConfig {
 }
 
 /**
- * Represents a signal that can be read from but not written to.
- * Both `StateSignal` and `ComputedSignal` implement this interface, allowing them to be used
- * as dependencies in other signals without exposing their `set` or `dispatch` methods.
+ * Represents a signal that can be subscribed to for changes, but does not allow direct modification of its value.
+ * Both `StateSignal` and `EventSignal` implement this interface, allowing them to be used as dependencies in other signals
+ * without exposing their `set` or `dispatch` methods.
  *
  * @template T The type of the signal's value.
  */
-export interface IReadonlySignal<T> {
+export interface ISignal<T> {
   /**
    * The unique identifier for this signal instance. Useful for debugging.
    */
   readonly name: string;
-
-  /**
-   * The current value of the signal.
-   */
-  get: () => T;
 
   /**
    * Indicates whether the signal has been destroyed.
@@ -181,6 +176,20 @@ export interface IReadonlySignal<T> {
    * garbage collection of the signal and its observers.
    */
   destroy(): void;
+}
+
+/**
+ * Represents a signal that can be read from but not written to.
+ * Both `StateSignal` and `ComputedSignal` implement this interface, allowing them to be used
+ * as dependencies in other signals without exposing their `set` or `dispatch` methods.
+ *
+ * @template T The type of the signal's value.
+ */
+export interface IReadonlySignal<T> extends ISignal<T> {
+  /**
+   * The current value of the signal.
+   */
+  get: () => T;
 }
 
 /**

--- a/pkg/nanolib/signal/src/type.ts
+++ b/pkg/nanolib/signal/src/type.ts
@@ -126,12 +126,11 @@ export interface StateSignalConfig<T> extends SignalConfig {
 
 /**
  * Represents a signal that can be subscribed to for changes, but does not allow direct modification of its value.
- * Both `StateSignal` and `EventSignal` implement this interface, allowing them to be used as dependencies in other signals
- * without exposing their `set` or `dispatch` methods.
+ * This is the base interface for both `StateSignal` and `ComputedSignal`, allowing them to be used as dependencies
  *
  * @template T The type of the signal's value.
  */
-export interface ISignal<T> {
+export interface IBaseSignal<T> {
   /**
    * The unique identifier for this signal instance. Useful for debugging.
    */
@@ -185,7 +184,7 @@ export interface ISignal<T> {
  *
  * @template T The type of the signal's value.
  */
-export interface IReadonlySignal<T> extends ISignal<T> {
+export interface IReadonlySignal<T> extends IBaseSignal<T> {
   /**
    * The current value of the signal.
    */


### PR DESCRIPTION
## Description

Improved type definitions for the `EventSignal` and `IReadonlySignal` interfaces, enhancing type safety by updating the `subscribe_` method to use `ISignal`. This change ensures better consistency and clarity in signal handling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **بهبودی**
  * بهبود API سیگنال و تحکیم ساختار تایپ‌های سیستم سیگنال برای سازگاری بهتر
  * بازسازی تعریفات رابط‌های سیگنال برای حذف تکرار و بهبود معماری

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alwatr/alwatr/pull/1810)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->