### PR TITLE
feat(on-action-array): support handling multiple action types in onAc…

### DIFF
--- a/pkg/flux/README.md
+++ b/pkg/flux/README.md
@@ -752,16 +752,23 @@ setupActionDelegation([...DEFAULT_DELEGATED_EVENTS, 'keydown', 'focus']);
 
 #### `onAction<K>(type, handler)`
 
-Subscribes to a typed action. The handler receives the full `Action<K>` object.
+Subscribes to a single typed action or an array of actions. The handler receives the full `Action<K>` object.
 
 ```typescript
+// Subscribe to a single action
 const sub = onAction('ui_add_to_cart', (action) => {
   cartService.add(action.payload.productId, action.payload.qty);
   console.log(action.context); // e.g. 'product-list' or undefined
   console.log(action.meta); // any metadata set by modifiers
 });
 
+// Subscribe to multiple actions with a single handler
+const multiSub = onAction(['ui_increment', 'ui_decrement'], (action) => {
+  console.log('Action triggered:', action.type);
+});
+
 sub.unsubscribe(); // Clean up when done
+multiSub.unsubscribe();
 ```
 
 #### `dispatchAction<K>(action)`

--- a/pkg/nanolib/action/README.md
+++ b/pkg/nanolib/action/README.md
@@ -347,18 +347,29 @@ function teardownActionDelegation(): void;
 
 ### `onAction(type, handler)`
 
-Subscribes to a named action. O(1) routing via `ChannelSignal`. The handler receives the full `Action<K>` object.
+Subscribes to a single named action or an array of actions. O(1) routing via `ChannelSignal`. The handler receives the full `Action<K>` object.
 
 ```ts
-function onAction<K extends keyof ActionRecord>(type: K, handler: (action: Action<K>) => void): SubscribeResult;
+function onAction<K extends keyof ActionRecord>(
+  type: K | K[],
+  handler: (action: Action<K>) => Awaitable<void>,
+): SubscribeResult;
 ```
 
 ```ts
+// Subscribe to a single action
 const sub = onAction('ui_open_drawer', (action) => {
   openDrawer(action.payload); // payload: string
   console.log(action.context); // e.g. 'sidebar' or undefined
 });
+
+// Subscribe to multiple actions with a single handler
+const multiSub = onAction(['ui_increment', 'ui_decrement'], (action) => {
+  console.log('Action triggered:', action.type);
+});
+
 sub.unsubscribe(); // prevent memory leaks
+multiSub.unsubscribe();
 ```
 
 ---

--- a/pkg/nanolib/action/src/method.test.js
+++ b/pkg/nanolib/action/src/method.test.js
@@ -96,6 +96,26 @@ describe('Action — Programmatic API', () => {
       subB.unsubscribe();
     });
 
+    it('should subscribe to multiple action types when given an array of types', async () => {
+      const callback = jest.fn();
+      const sub = onAction(['action_x', 'action_y'], callback);
+
+      dispatchAction({type: 'action_x', payload: 'data_x'});
+      await nextMacrotask();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith({type: 'action_x', payload: 'data_x'});
+
+      dispatchAction({type: 'action_y', payload: 'data_y'});
+      await nextMacrotask();
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenLastCalledWith({type: 'action_y', payload: 'data_y'});
+
+      sub.unsubscribe();
+      dispatchAction({type: 'action_x', payload: 'more_data'});
+      await nextMacrotask();
+      expect(callback).toHaveBeenCalledTimes(2); // no more calls
+    });
+
     it('should handle multiple dispatches in sequence', async () => {
       const callback = jest.fn();
       const sub = onAction('multi_dispatch', callback);

--- a/pkg/nanolib/action/src/method.ts
+++ b/pkg/nanolib/action/src/method.ts
@@ -1,4 +1,4 @@
-import type {Awaitable, SingleOrArray} from '@alwatr/type-helper';
+import type {Awaitable, VoidFunc} from '@alwatr/type-helper';
 import type {SubscribeResult} from '@alwatr/signal';
 
 import {internalChannel_, logger_} from './lib_.js';
@@ -54,7 +54,7 @@ import type {Action, ActionRecord, DispatchParam, ModifierHandler, PayloadResolv
  * ```
  */
 export function onAction<K extends keyof ActionRecord>(
-  type: SingleOrArray<K>,
+  type: K | K[],
   handler: (action: Action<K>) => Awaitable<void>,
 ): SubscribeResult {
   logger_.logMethodArgs?.('onAction', {type});
@@ -62,18 +62,21 @@ export function onAction<K extends keyof ActionRecord>(
   // the channel key guarantees the type matches — only Action<K> objects are
   // ever dispatched under key K.
   if (Array.isArray(type)) {
-    const results: SubscribeResult[] = [];
-    for (const t of type) {
-      results.push(internalChannel_.on(t, handler as (action: Action) => Awaitable<void>));
+    const typeList = type as K[];
+    const unsubscribeList: VoidFunc[] = [];
+    for (const type_ of typeList) {
+      unsubscribeList.push(internalChannel_.on(type_, handler as (action: Action) => Awaitable<void>).unsubscribe);
     }
     return {
       unsubscribe: () => {
-        for (const s of results) {
-          s.unsubscribe();
+        for (const unsubscribe of unsubscribeList) {
+          unsubscribe();
         }
+        unsubscribeList.length = 0;
       },
     };
   }
+  // else single type
   return internalChannel_.on(type, handler as (action: Action) => Awaitable<void>);
 }
 

--- a/pkg/nanolib/action/src/method.ts
+++ b/pkg/nanolib/action/src/method.ts
@@ -1,4 +1,4 @@
-import type {Awaitable} from '@alwatr/type-helper';
+import type {Awaitable, SingleOrArray} from '@alwatr/type-helper';
 import type {SubscribeResult} from '@alwatr/signal';
 
 import {internalChannel_, logger_} from './lib_.js';
@@ -54,13 +54,26 @@ import type {Action, ActionRecord, DispatchParam, ModifierHandler, PayloadResolv
  * ```
  */
 export function onAction<K extends keyof ActionRecord>(
-  type: K,
+  type: SingleOrArray<K>,
   handler: (action: Action<K>) => Awaitable<void>,
 ): SubscribeResult {
   logger_.logMethodArgs?.('onAction', {type});
   // The internal channel stores Action<any>; we cast to Action<K> here because
   // the channel key guarantees the type matches — only Action<K> objects are
   // ever dispatched under key K.
+  if (Array.isArray(type)) {
+    const results: SubscribeResult[] = [];
+    for (const t of type) {
+      results.push(internalChannel_.on(t, handler as (action: Action) => Awaitable<void>));
+    }
+    return {
+      unsubscribe: () => {
+        for (const s of results) {
+          s.unsubscribe();
+        }
+      },
+    };
+  }
   return internalChannel_.on(type, handler as (action: Action) => Awaitable<void>);
 }
 


### PR DESCRIPTION
I gave this error type but cant handel it.
please fix it before merge @alimd 
Type 'SingleOrArray<K>' must have a '[Symbol.iterator]()' method that returns an iterator.ts(2488)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ویژگی‌های جدید**
  * امکان اشتراک‌گذاری هم‌زمان روی چند نوع اکشن و یک تابع لغو متحد برای همهٔ اشتراک‌ها

* **مستندات**
  * نمونه‌ها و توضیحات API برای اشتراک تک‌اکشن و چند‌اکشن به‌روزرسانی شد، شامل رفتار unsubscribe و پذیرش عملیات ناهمزمان توسط هندلر

* **تست‌ها**
  * تست جدید پوشش رفتار اشتراک روی آرایه‌ای از انواع اکشن‌ها و عملکرد فراخوانی‌ها و لغو اشتراک اضافه شد

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Alwatr/alwatr/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->