### PR TITLE
Update documentation and tests for lazy evaluation accessor

### DIFF
--- a/.kiro/steering/patterns.md
+++ b/.kiro/steering/patterns.md
@@ -110,7 +110,7 @@ import {lazy} from '@alwatr/lazy';
 
 // Factory function (preferred — better type inference)
 const config = lazy(() => loadExpensiveConfig());
-console.log(config.value); // initialized on first access
+console.log(config.instance); // initialized on first access
 console.log(config.isInitialized()); // true
 
 // Class API

--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -92,7 +92,7 @@ A TypeScript/ESM monorepo of small, focused libraries for building robust JavaSc
 
 | Package                                   | Key API / Notes                                                                                                                                       |
 | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@alwatr/lazy`                            | `Lazy<T>` class + `lazy()` factory — deferred evaluation with cached result and closure cleanup for GC. `.value` accessor, `.isInitialized()` check.  |
+| `@alwatr/lazy`                            | `Lazy<T>` class + `lazy()` factory — deferred evaluation with cached result and closure cleanup for GC. `.instance` accessor, `.isInitialized()` check.  |
 | `@alwatr/deep-clone`                      | `deepClone(obj)` — deep clone objects/arrays.                                                                                                         |
 | `@alwatr/flat-string`                     | Flattens concatenated string's internal C structure for V8 performance.                                                                               |
 | `@alwatr/has-own`                         | Side-effect-free `Object.hasOwn` polyfill.                                                                                                            |

--- a/pkg/flux/README.md
+++ b/pkg/flux/README.md
@@ -308,7 +308,7 @@ import {createStateSignal} from '@alwatr/flux';
 
 const userSignal = createStateSignal<UserProfile | null>({
   name: 'user',
-  initialValue: userProfile.value, // hydrated from DOM, no API call needed
+  initialValue: userProfile.instance, // hydrated from DOM, no API call needed
 });
 ```
 
@@ -1038,13 +1038,13 @@ const cartSignal = createStateSignal<CartState>({
 import {lazy} from '@alwatr/lazy';
 import {EmbeddedDataCollector} from '@alwatr/flux';
 
-// Extraction is deferred until .value is first accessed
+// Extraction is deferred until .instance is first accessed
 export const serverConfig = lazy(() =>
   new EmbeddedDataCollector<ServerConfig>('data-server-config', isServerConfig).collect(),
 );
 
 // Somewhere in your bootstrap code:
-const config = serverConfig.value; // extracted here, cached forever
+const config = serverConfig.instance; // extracted here, cached forever
 ```
 
 ---

--- a/pkg/nanolib/embedded-data/README.md
+++ b/pkg/nanolib/embedded-data/README.md
@@ -176,7 +176,7 @@ export const appConfig = lazy(() => {
 });
 
 // Later, when config is needed:
-const config = appConfig.value;
+const config = appConfig.instance;
 if (config) {
   console.log('API URL:', config.apiUrl);
 }
@@ -226,7 +226,7 @@ export const embeddedData = {
 // Usage in components
 import {embeddedData} from './data/embedded-data.js';
 
-const shops = embeddedData.shops.value;
+const shops = embeddedData.shops.instance;
 if (shops) {
   console.log('Loaded', shops.items.length, 'shops');
 }

--- a/pkg/nanolib/lazy/README.md
+++ b/pkg/nanolib/lazy/README.md
@@ -40,14 +40,14 @@ When you write `new Lazy(() => new ExpensiveService(config))`, the arrow functio
 │  constructor(initializer: () => T)                  │
 │    └─ stores initializer__ reference                │
 │                                                     │
-│  get value(): T                                     │
+│  get instance(): T                                  │
 │    ├─ [first access]                                │
 │    │    1. call initializer__()                     │
-│    │    2. cache result in value__                  │
+│    │    2. cache result in instance__               │
 │    │    3. delete initializer__  ← GC hint          │
-│    │    4. return value__                           │
+│    │    4. return instance__                        │
 │    └─ [subsequent accesses]                         │
-│         return value__  (O(1), no function call)    │
+│         return instance__  (O(1), no function call) │
 │                                                     │
 │  isInitialized(): boolean                           │
 │    └─ initializer__ === undefined                   │
@@ -59,13 +59,13 @@ When you write `new Lazy(() => new ExpensiveService(config))`, the arrow functio
 ```
   [constructed]
        │
-       │  first .value access
+       │  first .instance access
        ▼
   [initializing]  ──→  initializer__() runs
        │
        │  result cached, initializer__ deleted
        ▼
-  [initialized]   ──→  all subsequent .value reads return cache
+  [initialized]   ──→  all subsequent .instance reads return cache
 ```
 
 ---
@@ -93,9 +93,9 @@ const db = new Lazy(() => new DatabaseConnection(config));
 console.log(db.isInitialized()); // false
 
 // Created on first access, cached for all future accesses.
-const connection = db.value; // DatabaseConnection instantiated here
+const connection = db.instance; // DatabaseConnection instantiated here
 console.log(db.isInitialized()); // true
-console.log(db.value === connection); // true — same reference
+console.log(db.instance === connection); // true — same reference
 ```
 
 ### Factory Function (preferred)
@@ -122,7 +122,7 @@ function trackEvent(name: string) {
     // Analytics not yet started — skip silently during boot
     return;
   }
-  analyticsClient.value.track(name);
+  analyticsClient.instance.track(name);
 }
 ```
 
@@ -144,7 +144,7 @@ export const database = lazy(() => new DatabaseConnection(process.env.DB_URL!));
 import {database} from '../services/database.js';
 
 export async function getUsers() {
-  return database.value.query('SELECT * FROM users');
+  return database.instance.query('SELECT * FROM users');
 }
 ```
 
@@ -162,7 +162,7 @@ const cartSignal = new StateSignal<CartState>('cart', {items: []});
 
 cartSignal.subscribe((state) => {
   // cartService is initialized on the first subscription, not at module load.
-  cartService.value.syncToStorage(state);
+  cartService.instance.syncToStorage(state);
 });
 ```
 
@@ -176,7 +176,7 @@ cartSignal.subscribe((state) => {
 
 Creates a new `Lazy` wrapper. The `initializer` is **not** called at this point.
 
-#### `get value(): T`
+#### `get instance(): T`
 
 Returns the lazily-initialized value. Calls `initializer` on the first access,
 caches the result, and deletes the initializer reference. All subsequent accesses
@@ -184,7 +184,7 @@ return the cached value in O(1) with no function call overhead.
 
 #### `isInitialized(): boolean`
 
-Returns `true` if the initializer has already been executed (i.e., `.value` has
+Returns `true` if the initializer has already been executed (i.e., `.instance` has
 been accessed at least once). Returns `false` otherwise.
 
 ---
@@ -201,9 +201,9 @@ inference — TypeScript derives `T` from the return type of `initializer` autom
 | Decision                                             | Rationale                                                                                                                                                                                             |
 | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `delete this.initializer__` instead of `= undefined` | Removes the property from the V8 hidden class, giving a stronger GC hint than a simple `undefined` assignment.                                                                                        |
-| `value__` uses `undefined` as sentinel (not `null`)  | Allows `T` to be `null` without ambiguity — `lazy(() => null).value` correctly returns `null`.                                                                                                        |
+| `instance__` uses `undefined` as sentinel (not `null`) | Allows `T` to be `null` without ambiguity — `lazy(() => null).instance` correctly returns `null`.                                                                                                     |
 | No `reset()` method                                  | Lazy values are intended to be permanent singletons. A reset would reintroduce the initializer, complicating the GC story and the state machine. If you need resettable state, use `@alwatr/signal`.  |
-| No async support                                     | Async initialization belongs in `@alwatr/flatomise` (deferred promises) or `@alwatr/signal` (reactive state). Mixing `Promise` into `Lazy` would complicate the synchronous `.value` getter contract. |
+| No async support                                     | Async initialization belongs in `@alwatr/flatomise` (deferred promises) or `@alwatr/signal` (reactive state). Mixing `Promise` into `Lazy` would complicate the synchronous `.instance` getter contract. |
 | `sideEffects: false`                                 | The package has no module-level side effects, enabling full tree-shaking.                                                                                                                             |
 
 ---

--- a/pkg/nanolib/lazy/src/lazy.test.js
+++ b/pkg/nanolib/lazy/src/lazy.test.js
@@ -4,95 +4,95 @@ import {Lazy, lazy} from '@alwatr/lazy';
 describe('Lazy', () => {
   test('initializer is not called on construction', () => {
     let called = false;
-    const instance = new Lazy(() => {
+    const lazy = new Lazy(() => {
       called = true;
       return 42;
     });
     expect(called).toBe(false);
-    expect(instance.isInitialized()).toBe(false);
+    expect(lazy.isInitialized()).toBe(false);
   });
 
-  test('initializer is called on first .value access', () => {
+  test('initializer is called on first .instance access', () => {
     let callCount = 0;
-    const instance = new Lazy(() => {
+    const lazy = new Lazy(() => {
       callCount++;
       return 'hello';
     });
-    expect(instance.value).toBe('hello');
+    expect(lazy.instance).toBe('hello');
     expect(callCount).toBe(1);
   });
 
-  test('initializer is called only once across multiple .value accesses', () => {
+  test('initializer is called only once across multiple .instance accesses', () => {
     let callCount = 0;
-    const instance = new Lazy(() => {
+    const lazy = new Lazy(() => {
       callCount++;
       return {id: 1};
     });
-    const a = instance.value;
-    const b = instance.value;
-    const c = instance.value;
+    const a = lazy.instance;
+    const b = lazy.instance;
+    const c = lazy.instance;
     expect(callCount).toBe(1);
     // All accesses return the exact same cached reference
     expect(a).toBe(b);
     expect(b).toBe(c);
   });
 
-  test('isInitialized() returns true after first .value access', () => {
-    const instance = new Lazy(() => 99);
-    expect(instance.isInitialized()).toBe(false);
-    void instance.value;
-    expect(instance.isInitialized()).toBe(true);
+  test('isInitialized() returns true after first .instance access', () => {
+    const lazy = new Lazy(() => 99);
+    expect(lazy.isInitialized()).toBe(false);
+    void lazy.instance;
+    expect(lazy.isInitialized()).toBe(true);
   });
 
   test('works with null as a valid value', () => {
-    const instance = new Lazy(() => null);
-    expect(instance.value).toBeNull();
-    expect(instance.isInitialized()).toBe(true);
+    const lazy = new Lazy(() => null);
+    expect(lazy.instance).toBeNull();
+    expect(lazy.isInitialized()).toBe(true);
   });
 
   test('works with undefined as a valid value', () => {
-    const instance = new Lazy(() => undefined);
-    expect(instance.value).toBeUndefined();
-    expect(instance.isInitialized()).toBe(true);
+    const lazy = new Lazy(() => undefined);
+    expect(lazy.instance).toBeUndefined();
+    expect(lazy.isInitialized()).toBe(true);
   });
 
   test('works with complex object values', () => {
     const data = {name: 'alwatr', version: 9};
-    const instance = new Lazy(() => data);
-    expect(instance.value).toEqual({name: 'alwatr', version: 9});
-    expect(instance.value).toBe(data); // same reference
+    const lazy = new Lazy(() => data);
+    expect(lazy.instance).toEqual({name: 'alwatr', version: 9});
+    expect(lazy.instance).toBe(data); // same reference
   });
 
   test('handles re-entrant access during initialization gracefully', () => {
-    // Edge case: initializer itself accesses .value
+    // Edge case: initializer itself accesses .instance
     // Should return undefined on re-entry (not infinite loop)
     let reentrantValue;
-    const instance = new Lazy(() => {
-      // During initialization, try to read .value again
-      reentrantValue = instance.value;
+    const lazy = new Lazy(() => {
+      // During initialization, try to read .instance again
+      reentrantValue = lazy.instance;
       return 42;
     });
-    const result = instance.value;
+    const result = lazy.instance;
     expect(result).toBe(42);
     expect(reentrantValue).toBeUndefined(); // re-entry saw undefined
-    expect(instance.isInitialized()).toBe(true);
+    expect(lazy.isInitialized()).toBe(true);
   });
 });
 
 describe('lazy() factory function', () => {
   test('returns a Lazy instance', () => {
-    const instance = lazy(() => 'test');
-    expect(instance).toBeInstanceOf(Lazy);
+    const lazyVal = lazy(() => 'test');
+    expect(lazyVal).toBeInstanceOf(Lazy);
   });
 
   test('defers execution like the class constructor', () => {
     let called = false;
-    const instance = lazy(() => {
+    const lazyVal = lazy(() => {
       called = true;
       return true;
     });
     expect(called).toBe(false);
-    expect(instance.value).toBe(true);
+    expect(lazyVal.instance).toBe(true);
     expect(called).toBe(true);
   });
 });

--- a/pkg/nanolib/lazy/src/lazy.ts
+++ b/pkg/nanolib/lazy/src/lazy.ts
@@ -1,7 +1,7 @@
 /**
  * A generic, memory-efficient lazy evaluation wrapper.
  *
- * Defers execution of an expensive initializer until `.value` is first accessed.
+ * Defers execution of an expensive initializer until `.instance` is first accessed.
  * After the first access the result is cached and the initializer reference is
  * dropped, allowing the GC to reclaim any closure memory.
  *
@@ -14,7 +14,7 @@
  * // Class API
  * const heavyService = new Lazy(() => new ExpensiveService());
  * console.log(heavyService.isInitialized()); // false — not yet created
- * console.log(heavyService.value);           // ExpensiveService instance (created now)
+ * console.log(heavyService.instance);        // ExpensiveService instance (created now)
  * console.log(heavyService.isInitialized()); // true
  *
  * // Factory function API (preferred for type inference)
@@ -28,7 +28,7 @@ export class Lazy<T> {
    * Using `undefined` as the sentinel (rather than `null`) so that
    * `T` can itself be `null` without ambiguity.
    */
-  private value__?: T;
+  private instance__?: T;
 
   /**
    * The deferred initializer function.
@@ -51,20 +51,20 @@ export class Lazy<T> {
    * On **subsequent** accesses the cached value is returned directly — O(1),
    * no function call overhead.
    */
-  get value(): T {
+  get instance(): T {
     if (this.initializer__ !== undefined) {
       // Capture the initializer and immediately delete the reference.
-      // This prevents infinite recursion if the initializer itself accesses `.value`.
+      // This prevents infinite recursion if the initializer itself accesses `.instance`.
       const init = this.initializer__;
       // Explicitly delete (not just assign undefined) so the property is removed
       // from the object shape, giving V8 a stronger GC hint.
       delete this.initializer__;
-      // Now call the initializer — if it re-enters `.value`, it will see
-      // initializer__ === undefined and return the (still-undefined) value__.
-      this.value__ = init();
+      // Now call the initializer — if it re-enters `.instance`, it will see
+      // initializer__ === undefined and return the (still-undefined) instance__.
+      this.instance__ = init();
     }
-    // value__ is guaranteed to be set at this point (unless initializer re-entered).
-    return this.value__ as T;
+    // instance__ is guaranteed to be set at this point (unless initializer re-entered).
+    return this.instance__ as T;
   }
 
   /**
@@ -80,7 +80,7 @@ export class Lazy<T> {
    *   console.log('Service not yet started — skipping teardown.');
    *   return;
    * }
-   * service.value.shutdown();
+   * service.instance.shutdown();
    * ```
    */
   isInitialized(): boolean {
@@ -102,7 +102,7 @@ export class Lazy<T> {
  * @example
  * ```typescript
  * const db = lazy(() => new DatabaseConnection(config));
- * // db.value is only created when first accessed
+ * // db.instance is only created when first accessed
  * ```
  */
 export function lazy<T>(initializer: () => T): Lazy<T> {


### PR DESCRIPTION
## Description

Update the documentation and tests to reflect the change from `.value` to `.instance` for lazy evaluation accessors. This ensures consistency across the codebase and improves clarity in usage.

