### PR TITLE
🧹 standardize build and export model

### DIFF
--- a/pkg/core/package.json
+++ b/pkg/core/package.json
@@ -15,11 +15,13 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     },
     "./node": {
       "types": "./dist/node.d.ts",
+      "development": "./dist/dev/node.js",
       "default": "./dist/node.js"
     }
   },
@@ -58,7 +60,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -68,7 +72,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/core/package.json
+++ b/pkg/core/package.json
@@ -18,11 +18,6 @@
       "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
-    },
-    "./node": {
-      "types": "./dist/node.d.ts",
-      "development": "./dist/dev/node.js",
-      "default": "./dist/node.js"
     }
   },
   "sideEffects": false,

--- a/pkg/devtools/package.json
+++ b/pkg/devtools/package.json
@@ -23,6 +23,7 @@
     "./node": {
       "types": "./dist/node.d.ts",
       "development": "./dist/dev/node.js",
+      "import": "./dist/node.js",
       "default": "./dist/node.js"
     }
   },

--- a/pkg/devtools/package.json
+++ b/pkg/devtools/package.json
@@ -16,11 +16,13 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     },
     "./node": {
       "types": "./dist/node.d.ts",
+      "development": "./dist/dev/node.js",
       "default": "./dist/node.js"
     }
   },
@@ -33,7 +35,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/*.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/*.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/*.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +47,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/flux/package.json
+++ b/pkg/flux/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alwatr/flux",
   "version": "9.33.0",
-  "description": "UI and reactive library bundle for ECMAScript (JavaScript/TypeScript) projects — signals, actions, directives, and storage.",
+  "description": "UI and reactive library bundle for ECMAScript (JavaScript/TypeScript) projects \u2014 signals, actions, directives, and storage.",
   "license": "MPL-2.0",
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com> (https://ali.mihandoost.com)",
   "type": "module",
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -42,7 +43,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -52,7 +55,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/fsm/package.json
+++ b/pkg/fsm/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -34,7 +35,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -44,7 +47,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/action/package.json
+++ b/pkg/nanolib/action/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alwatr/action",
   "version": "9.33.0",
-  "description": "Declarative DOM action-dispatch — bridge HTML attributes to typed signal handlers.",
+  "description": "Declarative DOM action-dispatch \u2014 bridge HTML attributes to typed signal handlers.",
   "license": "MPL-2.0",
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com> (https://ali.mihandoost.com)",
   "type": "module",
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -34,7 +35,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module-web src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module-web --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module-web --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -44,7 +47,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/async-queue/package.json
+++ b/pkg/nanolib/async-queue/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -31,7 +32,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -41,7 +44,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/bind/package.json
+++ b/pkg/nanolib/bind/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -35,7 +36,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -45,7 +48,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/crypto/package.json
+++ b/pkg/nanolib/crypto/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/cyrb53/package.json
+++ b/pkg/nanolib/cyrb53/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/debounce/package.json
+++ b/pkg/nanolib/debounce/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -30,7 +31,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -40,7 +43,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/dedupe/package.json
+++ b/pkg/nanolib/dedupe/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/deep-clone/package.json
+++ b/pkg/nanolib/deep-clone/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/delay/package.json
+++ b/pkg/nanolib/delay/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -35,7 +36,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -45,7 +48,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/directive/package.json
+++ b/pkg/nanolib/directive/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -35,7 +36,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module-web src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module-web --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module-web --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -45,7 +48,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/djb2-hash/package.json
+++ b/pkg/nanolib/djb2-hash/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/embedded-data/package.json
+++ b/pkg/nanolib/embedded-data/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/env/package.json
+++ b/pkg/nanolib/env/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/exit-hook/package.json
+++ b/pkg/nanolib/exit-hook/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -30,7 +31,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -40,7 +43,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/fetch/package.json
+++ b/pkg/nanolib/fetch/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -37,7 +38,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -47,7 +50,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/flat-string/package.json
+++ b/pkg/nanolib/flat-string/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/flatomise/package.json
+++ b/pkg/nanolib/flatomise/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/global-this/package.json
+++ b/pkg/nanolib/global-this/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/has-own/package.json
+++ b/pkg/nanolib/has-own/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/hash-string/package.json
+++ b/pkg/nanolib/hash-string/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/http-primer/package.json
+++ b/pkg/nanolib/http-primer/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/iranian-national-code-validator/package.json
+++ b/pkg/nanolib/iranian-national-code-validator/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/is-number/package.json
+++ b/pkg/nanolib/is-number/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/json2csv/package.json
+++ b/pkg/nanolib/json2csv/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/keyboard-shortcut/package.json
+++ b/pkg/nanolib/keyboard-shortcut/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -34,7 +35,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module-web src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module-web --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module-web --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -44,7 +47,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/lazy/package.json
+++ b/pkg/nanolib/lazy/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -28,7 +29,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -38,7 +41,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/local-storage/package.json
+++ b/pkg/nanolib/local-storage/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -32,7 +33,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -42,7 +45,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/node-fs/package.json
+++ b/pkg/nanolib/node-fs/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -35,7 +36,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -45,7 +48,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/page-ready/package.json
+++ b/pkg/nanolib/page-ready/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alwatr/page-ready",
   "version": "9.33.0",
-  "description": "Lightweight page identity signal for MPA routing — reads page-id attribute and notifies subscribers.",
+  "description": "Lightweight page identity signal for MPA routing \u2014 reads page-id attribute and notifies subscribers.",
   "license": "MPL-2.0",
   "author": "S. Ali Mihandoost <ali.mihandoost@gmail.com> (https://ali.mihandoost.com)",
   "type": "module",
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -34,7 +35,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module-web src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module-web --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module-web --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -44,7 +47,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/parse-duration/package.json
+++ b/pkg/nanolib/parse-duration/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -32,7 +33,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -42,7 +45,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/platform-info/package.json
+++ b/pkg/nanolib/platform-info/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -30,7 +31,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -40,7 +43,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/random/package.json
+++ b/pkg/nanolib/random/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/render-state/package.json
+++ b/pkg/nanolib/render-state/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -32,7 +33,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -42,7 +45,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/resolve-url/package.json
+++ b/pkg/nanolib/resolve-url/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/session-storage/package.json
+++ b/pkg/nanolib/session-storage/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -32,7 +33,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -42,7 +45,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/signal/package.json
+++ b/pkg/nanolib/signal/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -36,7 +37,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -46,7 +49,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanolib/unicode-digits/package.json
+++ b/pkg/nanolib/unicode-digits/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -29,7 +30,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -39,7 +42,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanotron-old/api-server/package.json
+++ b/pkg/nanotron-old/api-server/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanotron-old/pre-handlers/package.json
+++ b/pkg/nanotron-old/pre-handlers/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nanotron/package.json
+++ b/pkg/nanotron/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -35,7 +36,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -45,7 +48,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nitrobase-old/engine/package.json
+++ b/pkg/nitrobase-old/engine/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -40,7 +41,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -50,7 +53,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nitrobase-old/helper/package.json
+++ b/pkg/nitrobase-old/helper/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -35,7 +36,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -45,7 +48,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nitrobase-old/reference/package.json
+++ b/pkg/nitrobase-old/reference/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -37,7 +38,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -47,7 +50,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nitrobase-old/types/package.json
+++ b/pkg/nitrobase-old/types/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -33,7 +34,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -43,7 +46,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nitrobase-old/user-management/package.json
+++ b/pkg/nitrobase-old/user-management/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -38,7 +39,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -48,7 +51,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/nitrobase/package.json
+++ b/pkg/nitrobase/package.json
@@ -22,6 +22,7 @@
     "./client": {
       "types": "./dist/client.d.ts",
       "development": "./dist/dev/client.js",
+      "import": "./dist/client.js",
       "default": "./dist/client.js"
     }
   },

--- a/pkg/nitrobase/package.json
+++ b/pkg/nitrobase/package.json
@@ -15,11 +15,13 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     },
     "./client": {
       "types": "./dist/client.d.ts",
+      "development": "./dist/dev/client.js",
       "default": "./dist/client.js"
     }
   },
@@ -41,7 +43,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/*.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/*.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/*.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -51,7 +55,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/node/package.json
+++ b/pkg/node/package.json
@@ -15,11 +15,13 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     },
     "./node": {
       "types": "./dist/node.d.ts",
+      "development": "./dist/dev/node.js",
       "default": "./dist/node.js"
     }
   },
@@ -38,7 +40,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --preset=module src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --preset=module --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --preset=module --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -48,7 +52,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [

--- a/pkg/node/package.json
+++ b/pkg/node/package.json
@@ -18,11 +18,6 @@
       "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
-    },
-    "./node": {
-      "types": "./dist/node.d.ts",
-      "development": "./dist/dev/node.js",
-      "default": "./dist/node.js"
     }
   },
   "sideEffects": false,

--- a/pkg/playground/package.json
+++ b/pkg/playground/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
+      "development": "./dist/dev/main.js",
       "import": "./dist/main.js",
       "default": "./dist/main.js"
     }
@@ -34,7 +35,9 @@
   "scripts": {
     "b": "bun run build",
     "build": "bun run build:ts && bun run build:es",
-    "build:es": "nano-build --target=bun --debug src/main.ts",
+    "build:es": "bun run build:es:dev && bun run build:es:prod",
+    "build:es:dev": "nano-build --target=bun --debug --outdir=dist/dev src/main.ts",
+    "build:es:prod": "NODE_ENV=production nano-build --target=bun --debug --outdir=dist src/main.ts",
     "build:ts": "tsc --build",
     "cl": "bun run clean",
     "clean": "rm -rfv dist *.tsbuildinfo",
@@ -44,7 +47,7 @@
     "test": "ALWATR_DEBUG=0 bun test",
     "w": "bun run watch",
     "watch": "bun run watch:ts & bun run watch:es",
-    "watch:es": "bun run build:es --watch",
+    "watch:es": "bun run build:es:dev --watch",
     "watch:ts": "bun run build:ts --watch --preserveWatchOutput"
   },
   "files": [


### PR DESCRIPTION
🎯 **What**
Standardized the build and export configuration across all 52 packages in the monorepo to match the model used in the `@alwatr/logger` package. This includes splitting ES builds into `development` and `production` modes and updating `package.json` `exports` to include conditional mapping for development.

💡 **Why**
To ensure consistency across the monorepo and provide optimized production builds while maintaining a dedicated development build (with sourcemaps and no minification if needed, and allowing for `DEV_MODE` flags) that can be easily resolved by bundlers and Node.js using the `development` export condition.

✅ **Verification**
- Automated transformation using a custom Python script to ensure accuracy and consistency.
- Manually inspected `package.json` in various packages (`pkg/core`, `pkg/nanolib/delay`, `pkg/devtools`, etc.).
- Successfully ran build for `@alwatr/delay` and verified that both `dist/` and `dist/dev/` artifacts are correctly generated.
- Verified that the `development` condition is correctly placed before `import` and `default` in the `exports` block.

✨ **Result**
The entire monorepo now follows a unified, robust build and export pattern, improving developer experience and build optimization.

---
*PR created automatically by Jules for task [11180735432176234031](https://jules.google.com/task/11180735432176234031) started by @alimd*