### PR TITLE
Make action listeners optional and improve binding syntax

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -137,6 +137,7 @@
         "@alwatr/nano-build": "workspace:*",
         "@alwatr/standard": "workspace:*",
         "@alwatr/type-helper": "workspace:*",
+        "@happy-dom/global-registrator": "^20.10.2",
         "@types/node": "^24.13.1",
         "typescript": "^6.0.3",
       },

--- a/pkg/flux/README.md
+++ b/pkg/flux/README.md
@@ -388,7 +388,7 @@ import {service_binding, createStateSignal} from '@alwatr/flux';
 // 1. Create domain state signal
 const userSignal = createStateSignal({
   name: 'user',
-  initialValue: {firstName: 'Ali', lastName: 'Mihandoost', cart: []},
+  initialValue: {firstName: 'Ali', lastName: 'Mihandoost', cart: [], progress: '30%'},
 });
 
 // 2. Project domain state to flat view model representation
@@ -396,6 +396,7 @@ service_binding.createViewModel('user', userSignal, (u) => ({
   firstName: u.firstName,
   fullName: `${u.firstName} ${u.lastName}`,
   cartIsEmpty: u.cart.length === 0,
+  progress: u.progress,
 }));
 ```
 
@@ -403,22 +404,25 @@ In your HTML, bind properties using declarative attributes:
 
 ```html
 <!-- Text Content Binding -->
-<h2 bind-text="user.fullName">Loading...</h2>
+<h2 bind_text="user.fullName">Loading...</h2>
 
 <!-- Value Binding with active cursor position preservation guard -->
 <input
   type="text"
-  bind-value="user.firstName"
+  bind_value="user.firstName"
   on-input="ui_edit_name:$value"
 />
 
 <!-- Attribute Binding (boolean presence toggling / nullish removal) -->
-<button bind-attrib="disabled=user.cartIsEmpty">Checkout</button>
+<button bind_attrib="disabled=user.cartIsEmpty">Checkout</button>
+
+<!-- CSS Custom Property (Variable) Binding (nullish removal support) -->
+<div bind_css_var="--player-progress: user.progress"></div>
 
 <!-- Lazy Binding (evaluated only when element enters viewport) -->
 <div
-  bind-text="user.fullName"
-  lazy-bind
+  bind_text="user.fullName"
+  lazy_bind
 ></div>
 ```
 
@@ -426,7 +430,8 @@ In your HTML, bind properties using declarative attributes:
 
 - **Cursor Preservation**: Writing to input values directly in other frameworks often resets the cursor caret to the end of the text. `@alwatr/bind` compares values and only writes to the DOM if the value changed, preserving typing cursor position perfectly.
 - **Presence-Aware Attributes**: Binds attributes intelligently. A `boolean` value toggles attribute presence, a `nullish` value removes the attribute, and any other value sets the attribute as a string.
-- **Lazy Initialization**: Placing `lazy-bind` on elements defers signal subscription and DOM updates until the element physically intersects the viewport, optimizing rendering performance on large pages.
+- **CSS Variable Binding**: Dynamically sets custom style properties on elements, facilitating performance-oriented animations, progress bars, themes, and dynamic layout variables.
+- **Lazy Initialization**: Placing `lazy_bind` on elements defers signal subscription and DOM updates until the element physically intersects the viewport, optimizing rendering performance on large pages.
 
 ---
 
@@ -1157,13 +1162,13 @@ Destroys the ViewModel's computed signal and removes the namespace from the acti
 
 #### Directives HTML Syntax
 
-- **`bind-text="namespace.prop"`**
+- **`bind_text="namespace.prop"`**
   Updates the element's `textContent` to the property value. Maps nullish values (`null`/`undefined`) to `''`.
 
-- **`bind-value="namespace.prop"`**
+- **`bind_value="namespace.prop"`**
   Updates input element values safely. Skips DOM writing if the element's value is already equal to the bound value to prevent caret cursor jumping in active text inputs.
 
-- **`bind-attrib="attr1=namespace.prop1; attr2=namespace.prop2"`**
+- **`bind_attrib="attr1=namespace.prop1; attr2=namespace.prop2"`**
   Updates target DOM attributes.
   - A boolean value toggles the attribute's presence.
   - A nullish value (`null` or `undefined`) removes the attribute.

--- a/pkg/fsm/src/fsm-service.test.js
+++ b/pkg/fsm/src/fsm-service.test.js
@@ -353,6 +353,39 @@ describe('FsmService', () => {
 
       internalFsm.destroy();
     });
+
+    it('should execute action effect during internal transitions', async () => {
+      const actionEffect = jest.fn();
+      const internalFsm = createFsmService({
+        name: 'internal-action-test',
+        initial: 'active',
+        context: {count: 0},
+        states: {
+          active: {
+            on: {
+              INCREMENT: {
+                assigner: (_, context) => ({...context, count: context.count + 1}),
+                action: actionEffect,
+              },
+            },
+          },
+        },
+      });
+
+      internalFsm.dispatch({type: 'INCREMENT'});
+      await nextMacrotask();
+
+      const state = internalFsm.stateSignal.get();
+      expect(state.name).toBe('active');
+      expect(state.context.count).toBe(1);
+      expect(actionEffect).toHaveBeenCalledTimes(1);
+      expect(actionEffect).toHaveBeenCalledWith(
+        expect.objectContaining({type: 'INCREMENT'}),
+        expect.objectContaining({count: 1}),
+      );
+
+      internalFsm.destroy();
+    });
   });
 
   // ── Multiple Assigners ────────────────────────────────────────────────────

--- a/pkg/fsm/src/fsm-service.ts
+++ b/pkg/fsm/src/fsm-service.ts
@@ -186,6 +186,10 @@ export class FsmService<
       this.executeEffects__(event, nextState.context, this.config_.states[nextState.name]?.entry);
       this.spawnActors__(event, nextState.context, this.config_.states[nextState.name]?.actor);
     }
+
+    if (!isExternalTransition && transition.action) {
+      this.executeEffects__(event, nextContext, transition.action);
+    }
   }
 
   /**

--- a/pkg/fsm/src/type.ts
+++ b/pkg/fsm/src/type.ts
@@ -113,18 +113,57 @@ export type StateActor<TEvent extends MachineEvent, TContext extends Record<stri
  * @template TEvent The type of the event.
  * @template TContext The type of the machine's context.
  */
-export interface Transition<
-  TState extends string,
-  TEvent extends MachineEvent,
-  TContext extends Record<string, unknown>,
-> {
-  /** The target state to transition to. If undefined, it's an internal transition. */
-  readonly target?: TState;
+export interface BaseTransition<TEvent extends MachineEvent, TContext extends Record<string, unknown>> {
   /** A guard function that must return true for the transition to occur. */
   readonly guard?: Guard<TEvent, TContext>;
   /** A single assigner or an ordered chain of assigners. Applied atomically. */
   readonly assigner?: SingleOrArray<Assigner<TEvent, TContext>>;
 }
+
+/**
+ * Defines an external transition that has a target state.
+ */
+export interface ExternalTransition<
+  TState extends string,
+  TEvent extends MachineEvent,
+  TContext extends Record<string, unknown>,
+> extends BaseTransition<TEvent, TContext> {
+  /** The target state to transition to. */
+  readonly target: TState;
+  /** Action effects are not allowed on external transitions. */
+  readonly action?: undefined;
+}
+
+/**
+ * Defines an internal transition that does not change the state (target is undefined)
+ * and can optionally execute an action effect.
+ */
+export interface InternalTransition<
+  TEvent extends MachineEvent,
+  TContext extends Record<string, unknown>,
+> extends BaseTransition<TEvent, TContext> {
+  /** The target state to transition to. For internal transitions, this is undefined. */
+  readonly target?: undefined;
+  /** Synchronous side-effects executed only for internal transitions. */
+  readonly action?: SingleOrArray<Effect<TEvent, TContext>>;
+}
+
+/**
+ * Defines a transition for a given state and event. It specifies the target state,
+ * assigners, and an optional guard.
+ *
+ * - With `target`: an **external** transition — exit effects run, actors are cleaned
+ *   up, then entry effects run and actors are re-spawned (even on self-transitions).
+ * - Without `target`: an **internal** transition — only assigners run; entry/exit
+ *   effects and actors are untouched, but optional `action` effects are executed.
+ *
+ * @template TState The type of the state.
+ * @template TEvent The type of the event.
+ * @template TContext The type of the machine's context.
+ */
+export type Transition<TState extends string, TEvent extends MachineEvent, TContext extends Record<string, unknown>> =
+  | ExternalTransition<TState, TEvent, TContext>
+  | InternalTransition<TEvent, TContext>;
 
 /**
  * Configuration options for persisting the FSM state in localStorage.

--- a/pkg/nanolib/action/README.md
+++ b/pkg/nanolib/action/README.md
@@ -239,6 +239,7 @@ on-<eventType>="actionId[:payload][; modifier1,modifier2,…]"
 | `:$value`    | `element.value` (for `<input>`, `<select>`, `<textarea>`)      |
 | `:$formdata` | `Object.fromEntries(new FormData(form))` from nearest `<form>` |
 | `:$checked`  | `(element as HTMLInputElement).checked` for checkboxes/radios  |
+| `:$dataset`  | `{...element.dataset}` containing all custom data attributes   |
 
 ---
 

--- a/pkg/nanolib/action/src/action-service.test.js
+++ b/pkg/nanolib/action/src/action-service.test.js
@@ -253,6 +253,17 @@ describe('ActionService — Built-in Modifiers & Resolvers', () => {
       expect(resolver({}, checkbox)).toBe(false);
     });
   });
+
+  describe('$dataset resolver', () => {
+    it('should resolve dataset properties as a plain object', () => {
+      const resolver = service['payloadRegistry__'].get('$dataset');
+      const element = document.createElement('div');
+      element.dataset.userId = '123';
+      element.dataset.role = 'admin';
+
+      expect(resolver({}, element)).toEqual({userId: '123', role: 'admin'});
+    });
+  });
 });
 
 // ─── 4. Event Delegation & Parsing ─────────────────────────────────────────────

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -485,6 +485,10 @@ export class ActionService {
     this.registerPayloadResolver('$checked', (_event, element) => {
       return 'checked' in element ? (element as HTMLInputElement).checked : null;
     });
+
+    this.registerPayloadResolver('$dataset', (_event, element) => {
+      return {...(element as HTMLElement).dataset};
+    });
   }
 }
 

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -467,6 +467,11 @@ export class ActionService {
       return form.checkValidity();
     });
 
+    this.registerModifier('stop', (event) => {
+      event.stopPropagation();
+      return true;
+    });
+
     // Built-in resolvers
     this.registerPayloadResolver('$value', (_event, element) => {
       return 'value' in element ? (element as {value: unknown}).value : null;

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -264,7 +264,7 @@ export class ActionService {
   registerModifier(name: string, handler: ModifierHandler): void {
     DEV_MODE && this.logger__.logMethodArgs?.('registerModifier', {name});
     if (this.modifierRegistry__.has(name)) {
-      this.logger__.accident('registerModifier', 'modifier_already_registered', {name});
+      DEV_MODE && this.logger__.accident('registerModifier', 'modifier_already_registered', {name});
       return;
     }
     this.modifierRegistry__.set(name, handler);
@@ -286,7 +286,7 @@ export class ActionService {
   registerPayloadResolver(name: string, resolver: PayloadResolver): void {
     DEV_MODE && this.logger__.logMethodArgs?.('registerPayloadResolver', {name});
     if (this.payloadRegistry__.has(name)) {
-      this.logger__.accident('registerPayloadResolver', 'payload_resolver_already_registered', {name});
+      DEV_MODE && this.logger__.accident('registerPayloadResolver', 'payload_resolver_already_registered', {name});
       return;
     }
     this.payloadRegistry__.set(name, resolver);
@@ -309,7 +309,7 @@ export class ActionService {
       return;
     }
 
-    for (const eventType of eventTypes) {
+    for (const eventType of new Set(eventTypes)) {
       if (this.delegatedEventTypes__.has(eventType)) continue;
       this.delegatedEventTypes__.add(eventType);
       document.body.addEventListener(eventType, this.handleDelegatedEventBound__, {capture: true});
@@ -348,7 +348,7 @@ export class ActionService {
 
     const match = attributeValue.match(syntaxRegex);
     if (!match) {
-      this.logger__.accident('parseDescriptor__', 'invalid_syntax', {attributeValue});
+      DEV_MODE && this.logger__.accident('parseDescriptor__', 'invalid_syntax', {attributeValue});
       this.descriptorCache__.set(attributeValue, null);
       return null;
     }
@@ -380,12 +380,13 @@ export class ActionService {
 
     const attributeValue = actionElement.getAttribute?.(actionAttrib)?.trim();
     if (!attributeValue) {
-      this.logger__.accident('handleDelegatedEvent__', 'empty_attribute', {eventType, actionElement});
+      DEV_MODE && this.logger__.accident('handleDelegatedEvent__', 'empty_attribute', {eventType, actionElement});
       return;
     }
 
     if (!(actionElement instanceof HTMLElement)) {
-      this.logger__.accident('handleDelegatedEvent__', 'target_not_html_element', {eventType, actionElement});
+      DEV_MODE
+        && this.logger__.accident('handleDelegatedEvent__', 'target_not_html_element', {eventType, actionElement});
       return;
     }
 
@@ -410,21 +411,23 @@ export class ActionService {
       if (modifier === 'once') continue;
       const handler = this.modifierRegistry__.get(modifier);
       if (!handler) {
-        this.logger__.accident('handleDelegatedEvent__', 'unknown_modifier', {
-          eventType,
-          modifier,
-          attributeValue,
-          descriptor,
-        });
+        DEV_MODE
+          && this.logger__.accident('handleDelegatedEvent__', 'unknown_modifier', {
+            eventType,
+            modifier,
+            attributeValue,
+            descriptor,
+          });
         return;
       }
       try {
         if (handler(event, actionElement, action) === false) return;
       } catch (error) {
-        this.logger__.accident('handleDelegatedEvent__', 'modifier_execution_failed', {
-          modifier,
-          error,
-        });
+        DEV_MODE
+          && this.logger__.accident('handleDelegatedEvent__', 'modifier_execution_failed', {
+            modifier,
+            error,
+          });
         return;
       }
     }
@@ -435,10 +438,11 @@ export class ActionService {
         try {
           (action as {payload: unknown}).payload = resolver(event, actionElement);
         } catch (error) {
-          this.logger__.accident('handleDelegatedEvent__', 'payload_resolver_failed', {
-            resolver: descriptor.payload,
-            error,
-          });
+          DEV_MODE
+            && this.logger__.accident('handleDelegatedEvent__', 'payload_resolver_failed', {
+              resolver: descriptor.payload,
+              error,
+            });
           return;
         }
       }

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -80,7 +80,7 @@ export class ActionService {
   private readonly descriptorCache__ = new Map<string, ActionDescriptor | null>();
 
   /**
-   * Tracked event types currently delegated to `document.body`.
+   * Tracked event types currently delegated to `document`.
    * @private
    */
   private readonly delegatedEventTypes__ = new Set<string>();
@@ -293,7 +293,7 @@ export class ActionService {
   }
 
   /**
-   * Registers global event delegation listeners on `document.body`.
+   * Registers global event delegation listeners on `document`.
    *
    * @param eventTypes - List of event types to delegate. Defaults to ActionService.DEFAULT_DELEGATED_EVENTS.
    *
@@ -304,15 +304,16 @@ export class ActionService {
    */
   setupDelegation(eventTypes: readonly string[] = ActionService.DEFAULT_DELEGATED_EVENTS): void {
     DEV_MODE && this.logger__.logMethodArgs?.('setupDelegation', {eventTypes});
-    if (typeof document === 'undefined' || !document.body) {
-      DEV_MODE && this.logger__.incident?.('setupDelegation', 'document_body_not_found');
+    if (typeof document === 'undefined') {
+      DEV_MODE && this.logger__.incident?.('setupDelegation', 'document_not_found');
       return;
     }
 
-    for (const eventType of new Set(eventTypes)) {
+    for (let index = 0; index < eventTypes.length; index++) {
+      const eventType = eventTypes[index];
       if (this.delegatedEventTypes__.has(eventType)) continue;
       this.delegatedEventTypes__.add(eventType);
-      document.body.addEventListener(eventType, this.handleDelegatedEventBound__, {capture: true});
+      document.addEventListener(eventType, this.handleDelegatedEventBound__, {capture: true});
     }
   }
 
@@ -326,11 +327,11 @@ export class ActionService {
    */
   teardownDelegation(): void {
     DEV_MODE && this.logger__.logMethod?.('teardownDelegation');
-    if (typeof document === 'undefined' || !document.body) {
+    if (typeof document === 'undefined') {
       return;
     }
     for (const eventType of this.delegatedEventTypes__) {
-      document.body.removeEventListener(eventType, this.handleDelegatedEventBound__, {capture: true});
+      document.removeEventListener(eventType, this.handleDelegatedEventBound__, {capture: true});
     }
     this.delegatedEventTypes__.clear();
     this.descriptorCache__.clear();

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -44,13 +44,13 @@ export class ActionService {
     // dialog events
     'cancel',
     // player events
-    'loadedmetadata',
-    'play',
-    'pause',
-    'timeupdate',
-    'ratechange',
-    'ended',
-    'error',
+    // 'loadedmetadata',
+    // 'play',
+    // 'pause',
+    // 'timeupdate',
+    // 'ratechange',
+    // 'ended',
+    // 'error',
   ];
 
   private readonly logger__ = createLogger('action_service');

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -139,7 +139,7 @@ export class ActionService {
    * ```
    */
   subscribeAll(listeners: {
-    readonly [K in keyof ActionRecord]: (action: Action<K>) => void;
+    readonly [K in keyof ActionRecord]?: (action: Action<K>) => void;
   }): SubscribeResult {
     DEV_MODE && this.logger__.logMethodArgs?.('subscribeAll', Object.keys(listeners));
     const keys = Object.keys(listeners) as (keyof ActionRecord)[];

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -85,12 +85,6 @@ export class ActionService {
    */
   private readonly delegatedEventTypes__ = new Set<string>();
 
-  /**
-   * Bound delegation handler for add/removeEventListener.
-   * @private
-   */
-  private readonly handleDelegatedEventBound__ = this.handleDelegatedEvent__.bind(this);
-
   constructor() {
     DEV_MODE && this.logger__.logMethod?.('constructor');
     this.registerDefaultModifiersAndResolvers__();
@@ -313,7 +307,7 @@ export class ActionService {
       const eventType = eventTypes[index];
       if (this.delegatedEventTypes__.has(eventType)) continue;
       this.delegatedEventTypes__.add(eventType);
-      document.addEventListener(eventType, this.handleDelegatedEventBound__, {capture: true});
+      document.addEventListener(eventType, this.handleDelegatedEvent__, {capture: true});
     }
   }
 
@@ -331,7 +325,7 @@ export class ActionService {
       return;
     }
     for (const eventType of this.delegatedEventTypes__) {
-      document.removeEventListener(eventType, this.handleDelegatedEventBound__, {capture: true});
+      document.removeEventListener(eventType, this.handleDelegatedEvent__, {capture: true});
     }
     this.delegatedEventTypes__.clear();
     this.descriptorCache__.clear();
@@ -368,7 +362,7 @@ export class ActionService {
    * Global event delegation handler.
    * @private
    */
-  private handleDelegatedEvent__(event: Event): void {
+  private handleDelegatedEvent__ = (event: Event): void => {
     const eventType = event.type;
     DEV_MODE && this.logger__.logMethodArgs?.('handleDelegatedEvent__', {eventType});
 
@@ -452,7 +446,7 @@ export class ActionService {
     }
 
     this.internalChannel__.dispatch(action.type, action);
-  }
+  };
 
   /**
    * Registers default modifiers and resolvers.

--- a/pkg/nanolib/action/src/action-service.ts
+++ b/pkg/nanolib/action/src/action-service.ts
@@ -34,7 +34,24 @@ export class ActionService {
   /**
    * Default DOM event types that cover the vast majority of interactive elements.
    */
-  static readonly DEFAULT_DELEGATED_EVENTS: readonly string[] = ['click', 'submit', 'input', 'change'];
+  static readonly DEFAULT_DELEGATED_EVENTS: readonly string[] = [
+    // mouse events
+    'click',
+    // form events
+    'submit',
+    'input',
+    'change',
+    // dialog events
+    'cancel',
+    // player events
+    'loadedmetadata',
+    'play',
+    'pause',
+    'timeupdate',
+    'ratechange',
+    'ended',
+    'error',
+  ];
 
   private readonly logger__ = createLogger('action_service');
 

--- a/pkg/nanolib/bind/README.md
+++ b/pkg/nanolib/bind/README.md
@@ -12,7 +12,7 @@ In traditional modern frameworks, updating state triggers virtual DOM reconcilia
 
 1. **Reactive Projections (ViewModels)**: Instead of binding raw, complex domain signals directly to the UI, you define flat **ViewModels** inside namespaces. These ViewModels project complex domain states into flat records of presentation-ready primitives (`string`, `number`, `boolean`, `null`, `undefined`).
 2. **Surgical DOM Updates**: Attributes on DOM elements act as binding anchors. The library hooks directly into the ViewModel's updates and modifies only the targeted text nodes or attributes—without re-running components or diffing trees.
-3. **Decoupled Binding**: Views declare _what_ to bind in HTML (`bind-text="user.fullName"`), and the JS controller defines _how_ that data gets derived. This keeps your HTML extremely readable and completely separates presentation from business logic.
+3. **Decoupled Binding**: Views declare _what_ to bind in HTML (`bind_text="user.fullName"`), and the JS controller defines _how_ that data gets derived. This keeps your HTML extremely readable and completely separates presentation from business logic.
 
 ---
 
@@ -20,12 +20,12 @@ In traditional modern frameworks, updating state triggers virtual DOM reconcilia
 
 - ⚡ **Zero Virtual DOM Overhead**: Updates map directly to `element.textContent`, `element.value`, or attributes.
 - 🎯 **Surgical Reactivity**: Only the DOM elements bound to the modified properties will re-render.
-- 🛡️ **Cursor Preservation Guard (`bind-value`)**: Binds input element values securely, checking for changes before writing to the DOM. This guards against the browser resetting the text cursor position while typing in an input field.
-- 💡 **Presence-Aware Attribute Binding (`bind-attrib`)**:
+- 🛡️ **Cursor Preservation Guard (`bind_value`)**: Binds input element values securely, checking for changes before writing to the DOM. This guards against the browser resetting the text cursor position while typing in an input field.
+- 💡 **Presence-Aware Attribute Binding (`bind_attrib`)**:
   - `boolean` values toggle the _presence_ of the attribute (perfect for `disabled`, `checked`, `hidden`).
   - `null`/`undefined` values _remove_ the attribute from the DOM.
   - Primitive values set the attribute value as a string.
-- 💤 **Lazy Viewport Evaluation (`lazy-bind`)**: Defer binding registration and signal subscription until the element physically enters the viewport (using `IntersectionObserver` via `@alwatr/directive`). This is ideal for off-screen cards, slow-loading inputs, or heavy dashboard elements.
+- 💤 **Lazy Viewport Evaluation (`lazy_bind`)**: Defer binding registration and signal subscription until the element physically enters the viewport (using `IntersectionObserver` via `@alwatr/directive`). This is ideal for off-screen cards, slow-loading inputs, or heavy dashboard elements.
 
 ---
 
@@ -38,7 +38,7 @@ Call `setupBindDirectives()` at your application's bootstrap phase to register t
 ```typescript
 import {setupBindDirectives} from '@alwatr/bind';
 
-// Register bind-text, bind-value, and bind-attrib directives
+// Register bind_text, bind_value, and bind_attrib directives
 setupBindDirectives();
 ```
 
@@ -90,22 +90,22 @@ Use the declarative attributes to bind elements to the ViewModel.
 
 ```html
 <!-- Binds textContent to 'user.fullName' -->
-<h2 bind-text="user.fullName">Loading user...</h2>
+<h2 bind_text="user.fullName">Loading user...</h2>
 
 <!-- Binds input value with cursor position preservation -->
 <input
   type="text"
-  bind-value="user.firstName"
+  bind_value="user.firstName"
   on-input="ui_edit_first_name:$value"
 />
 
 <!-- Binds 'disabled' attribute based on boolean state, and 'aria-busy' based on loading -->
-<button bind-attrib="disabled=user.cartIsEmpty; aria-busy=user.showLoading">Checkout</button>
+<button bind_attrib="disabled=user.cartIsEmpty; aria-busy=user.showLoading">Checkout</button>
 
 <!-- Lazy loading: updates only when scroll brings the card into viewport -->
 <div
-  bind-text="user.fullName"
-  lazy-bind
+  bind_text="user.fullName"
+  lazy_bind
 ></div>
 ```
 
@@ -141,11 +141,11 @@ Destroys the ViewModel computed signal, unsubscribing from the source signal, an
 
 ## 🧩 HTML Attribute Directives
 
-### `bind-text="namespace.property"`
+### `bind_text="namespace.property"`
 
 Sets the element's `textContent` to the string value of the ViewModel's property. Maps `null`/`undefined` to `''`.
 
-### `bind-value="namespace.property"`
+### `bind_value="namespace.property"`
 
 Sets the element's `value` attribute (for inputs, selects, textareas). Features a **DOM write guard**:
 
@@ -157,7 +157,7 @@ if (inputEl.value !== nextValue) {
 
 This ensures that user input typing feels smooth and the text cursor does not reset or jump to the end of the input field.
 
-### `bind-attrib="attr1=namespace.prop1; attr2=namespace.prop2"`
+### `bind_attrib="attr1=namespace.prop1; attr2=namespace.prop2"`
 
 Binds element attributes to ViewModel properties. Multiple attributes are semicolon-separated.
 
@@ -167,7 +167,7 @@ Binds element attributes to ViewModel properties. Multiple attributes are semico
 - **Nullish values (`null`/`undefined`)**: Removes the attribute entirely.
 - **Other values**: Sets the attribute value coerced as a string.
 
-### `lazy-bind`
+### `lazy_bind`
 
 When placed alongside any of the above binding attributes, the directive delays its ViewModel subscription and DOM update cycle until the element intersects with the viewport. This dramatically boosts initial boot time and reduces active subscriptions for long or heavy pages.
 

--- a/pkg/nanolib/bind/package.json
+++ b/pkg/nanolib/bind/package.json
@@ -30,6 +30,7 @@
     "@alwatr/nano-build": "workspace:*",
     "@alwatr/standard": "workspace:*",
     "@alwatr/type-helper": "workspace:*",
+    "@happy-dom/global-registrator": "^20.10.2",
     "@types/node": "^24.13.1",
     "typescript": "^6.0.3"
   },

--- a/pkg/nanolib/bind/src/directive_bind_attrib.ts
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.ts
@@ -15,7 +15,7 @@ import {service_binding, type BindingValue} from './main.js';
  * - Any other type: Coerced via `String(value)` and set as the attribute's value.
  *
  * Includes a redundant write guard (via `lastValues_`) that skips calls to the DOM if the property value hasn't changed.
- * Supports deferred viewport initialization if the `lazy-bind` attribute is present on the element.
+ * Supports deferred viewport initialization if the `lazy_bind` attribute is present on the element.
  *
  * @example
  * ```html
@@ -26,20 +26,20 @@ import {service_binding, type BindingValue} from './main.js';
  * <img bind_attrib="src=user.avatarUrl; alt=user.fullName" />
  *
  * <!-- Lazy attribute binding -->
- * <iframe bind_attrib="src=video.embedUrl" lazy-bind></iframe>
+ * <iframe bind_attrib="src=video.embedUrl" lazy_bind></iframe>
  * ```
  */
 export class BindAttribDirective extends Directive {
   /**
    * Attribute flag used to defer binding initialization until the element enters the viewport.
-   * If `lazy-bind` attribute exists, this is non-null.
+   * If `lazy_bind` attribute exists, this is non-null.
    */
-  @attribute('lazy-bind')
+  @attribute('lazy_bind')
   protected accessor lazyBinding_!: null | string;
 
   /**
    * Initializes the directive.
-   * Checks if lazy binding is enabled via `lazy-bind`.
+   * Checks if lazy binding is enabled via `lazy_bind`.
    * If yes, delegates the initialization to `lazyInit_`; otherwise, initializes immediately.
    */
   protected override init_(): void {

--- a/pkg/nanolib/bind/src/directive_bind_attrib.ts
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.ts
@@ -5,7 +5,7 @@ import {service_binding, type BindingValue} from './main.js';
 /**
  * A declarative DOM directive that binds DOM element attributes to view model properties.
  *
- * Syntax: `bind-attrib="attributeName=namespace.propertyName; anotherAttribute=namespace.anotherProperty"`
+ * Syntax: `bind_attrib="attributeName=namespace.propertyName; anotherAttribute=namespace.anotherProperty"`
  *
  * Supports binding multiple attributes on the same element separated by semicolons (`;`).
  *
@@ -20,13 +20,13 @@ import {service_binding, type BindingValue} from './main.js';
  * @example
  * ```html
  * <!-- Binds presence of 'disabled' to cart emptiness and 'aria-busy' to loading state -->
- * <button bind-attrib="disabled=user.cartIsEmpty; aria-busy=ui.loading">Checkout</button>
+ * <button bind_attrib="disabled=user.cartIsEmpty; aria-busy=ui.loading">Checkout</button>
  *
  * <!-- Binds 'src' and 'alt' attributes -->
- * <img bind-attrib="src=user.avatarUrl; alt=user.fullName" />
+ * <img bind_attrib="src=user.avatarUrl; alt=user.fullName" />
  *
  * <!-- Lazy attribute binding -->
- * <iframe bind-attrib="src=video.embedUrl" lazy-bind></iframe>
+ * <iframe bind_attrib="src=video.embedUrl" lazy-bind></iframe>
  * ```
  */
 export class BindAttribDirective extends Directive {
@@ -111,6 +111,6 @@ export class BindAttribDirective extends Directive {
 }
 
 /**
- * Helper to register `BindAttribDirective` lazily under the `bind-attrib` attribute.
+ * Helper to register `BindAttribDirective` lazily under the `bind_attrib` attribute.
  */
-export const registerBindAttribDirective = lazyDirective('bind-attrib', BindAttribDirective);
+export const registerBindAttribDirective = lazyDirective('bind_attrib', BindAttribDirective);

--- a/pkg/nanolib/bind/src/directive_bind_attrib.ts
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.ts
@@ -70,13 +70,13 @@ export class BindAttribDirective extends Directive {
       const [attributeName, viewKey_ = ''] = pair.split('=');
       const [namespace, prop] = viewKey_.split('.');
       if (!attributeName || !namespace || !prop) {
-        this.logger_.accident?.('bindingInit_', 'invalid_binding_pair', {pair});
+        DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding_pair', {pair});
         continue;
       }
 
       const viewModel = service_binding.getViewModel(namespace);
       if (!viewModel) {
-        this.logger_.accident?.('bindingInit_', 'missing_view_model', {namespace});
+        DEV_MODE && this.logger_.accident('bindingInit_', 'missing_view_model', {namespace});
         continue;
       }
 

--- a/pkg/nanolib/bind/src/directive_bind_css_var.test.js
+++ b/pkg/nanolib/bind/src/directive_bind_css_var.test.js
@@ -1,0 +1,136 @@
+// Define DEV_MODE globally so that TS source files can run directly in bun test
+globalThis.DEV_MODE = true;
+
+import {describe, it, expect, beforeEach, afterEach} from 'bun:test';
+import {GlobalRegistrator} from '@happy-dom/global-registrator';
+import {createStateSignal} from '@alwatr/signal';
+import {bootstrapDirectives} from '@alwatr/directive';
+import {service_binding, setupBindDirectives} from './main.js';
+
+// Register DOM globals if not already done (guard against double-registration)
+if (typeof document === 'undefined') {
+  GlobalRegistrator.register();
+}
+
+/** Wait for the constructor's IIFE and microtasks to complete */
+const waitForInit = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+describe('BindCssVarDirective', () => {
+  let signal;
+
+  beforeEach(() => {
+    // Ensure all directives are registered
+    setupBindDirectives(true);
+    signal = createStateSignal({
+      name: 'test-player-signal',
+      initialValue: {
+        progress: '30%',
+        color: 'red',
+      },
+    });
+    service_binding.createViewModel('player', signal, (s) => ({
+      progress: s.progress,
+      color: s.color,
+    }));
+  });
+
+  afterEach(() => {
+    service_binding.removeViewModel('player');
+    document.body.innerHTML = '';
+  });
+
+  it('should bind a single CSS variable to element style', async () => {
+    const el = document.createElement('div');
+    el.setAttribute('bind_css_var', '--player-progress: player.progress');
+    document.body.appendChild(el);
+
+    // Bootstrap directives on the page to find the newly added element
+    bootstrapDirectives();
+    await waitForInit();
+
+    expect(el.style.getPropertyValue('--player-progress')).toBe('30%');
+
+    // Update state
+    signal.set({progress: '50%', color: 'blue'});
+    await waitForInit();
+
+    expect(el.style.getPropertyValue('--player-progress')).toBe('50%');
+  });
+
+  it('should bind multiple CSS variables to element style', async () => {
+    const el = document.createElement('div');
+    el.setAttribute('bind_css_var', '--player-progress: player.progress; --player-color: player.color');
+    document.body.appendChild(el);
+
+    bootstrapDirectives();
+    await waitForInit();
+
+    expect(el.style.getPropertyValue('--player-progress')).toBe('30%');
+    expect(el.style.getPropertyValue('--player-color')).toBe('red');
+
+    // Update state
+    signal.set({progress: '80%', color: 'green'});
+    await waitForInit();
+
+    expect(el.style.getPropertyValue('--player-progress')).toBe('80%');
+    expect(el.style.getPropertyValue('--player-color')).toBe('green');
+  });
+
+  it('should remove the CSS variable when value is null or undefined', async () => {
+    const el = document.createElement('div');
+    el.setAttribute('bind_css_var', '--player-progress: player.progress');
+    document.body.appendChild(el);
+
+    bootstrapDirectives();
+    await waitForInit();
+
+    expect(el.style.getPropertyValue('--player-progress')).toBe('30%');
+
+    // Set progress to null
+    signal.set({progress: null, color: 'red'});
+    await waitForInit();
+
+    expect(el.style.getPropertyValue('--player-progress')).toBe('');
+
+    // Set progress to undefined
+    signal.set({progress: undefined, color: 'red'});
+    await waitForInit();
+
+    expect(el.style.getPropertyValue('--player-progress')).toBe('');
+  });
+
+  it('should defer binding when lazy_bind is present', async () => {
+    const originalIO = globalThis.IntersectionObserver;
+    let intersectCallback;
+    globalThis.IntersectionObserver = class MockIO {
+      constructor(cb) {
+        intersectCallback = cb;
+      }
+      observe() {}
+      disconnect() {}
+    };
+
+    const el = document.createElement('div');
+    el.setAttribute('bind_css_var', '--player-progress: player.progress');
+    el.setAttribute('lazy_bind', '');
+    document.body.appendChild(el);
+
+    bootstrapDirectives();
+    await waitForInit();
+
+    // Should not be bound yet since it hasn't intersected
+    expect(el.style.getPropertyValue('--player-progress')).toBe('');
+
+    // Trigger intersection
+    if (intersectCallback) {
+      intersectCallback([{isIntersecting: true}]);
+    }
+    await waitForInit();
+
+    // Now it should be bound
+    expect(el.style.getPropertyValue('--player-progress')).toBe('30%');
+
+    // Clean up mock
+    globalThis.IntersectionObserver = originalIO;
+  });
+});

--- a/pkg/nanolib/bind/src/directive_bind_css_var.ts
+++ b/pkg/nanolib/bind/src/directive_bind_css_var.ts
@@ -75,7 +75,7 @@ export class BindCssVarDirective extends Directive {
       const viewKey_ = pair.substring(index + 1).trim();
       const [namespace, prop] = viewKey_.split('.');
 
-      if (!cssVarName || !namespace || !prop) {
+      if (!cssVarName || !namespace || !prop || !cssVarName.startsWith('--')) {
         DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding_pair', {pair});
         continue;
       }

--- a/pkg/nanolib/bind/src/directive_bind_css_var.ts
+++ b/pkg/nanolib/bind/src/directive_bind_css_var.ts
@@ -1,0 +1,117 @@
+import {attribute, Directive, lazyDirective} from '@alwatr/directive';
+
+import {service_binding, type BindingValue} from './main.js';
+
+/**
+ * A declarative DOM directive that binds CSS custom properties (variables) to view model properties.
+ *
+ * Syntax: `bind_css_var="--var-name: namespace.propertyName; --another-var: namespace.anotherProperty"`
+ *
+ * Supports binding multiple CSS variables on the same element separated by semicolons (`;`).
+ *
+ * Behavior:
+ * - `null` / `undefined` value: Removes the CSS variable from the element's inline style.
+ * - Any other type: Coerced via `String(value)` and set as the CSS variable's value on the element's style.
+ *
+ * Includes a redundant write guard (via `lastValues_`) that skips calls to the DOM if the property value hasn't changed.
+ * Supports deferred viewport initialization if the `lazy_bind` attribute is present on the element.
+ *
+ * @example
+ * ```html
+ * <!-- Binds '--player-progress' to 'player.progress' -->
+ * <div bind_css_var="--player-progress: player.progress"></div>
+ *
+ * <!-- Binds multiple CSS variables -->
+ * <div bind_css_var="--color: theme.primaryColor; --font-size: theme.fontSize"></div>
+ *
+ * <!-- Lazy CSS variable binding -->
+ * <div bind_css_var="--opacity: ui.opacity" lazy_bind></div>
+ * ```
+ */
+export class BindCssVarDirective extends Directive {
+  /**
+   * Attribute flag used to defer binding initialization until the element enters the viewport.
+   * If `lazy_bind` attribute exists, this is non-null.
+   */
+  @attribute('lazy_bind')
+  protected accessor lazyBinding_!: null | string;
+
+  /**
+   * Initializes the directive.
+   * Checks if lazy binding is enabled via `lazy_bind`.
+   * If yes, delegates the initialization to `lazyInit_`; otherwise, initializes immediately.
+   */
+  protected override init_(): void {
+    DEV_MODE && this.logger_.logMethod?.('init_');
+    if (this.lazyBinding_ === null) {
+      this.bindingInit_();
+    } else {
+      this.lazyInit_ = this.bindingInit_;
+    }
+  }
+
+  /**
+   * Cache of the last applied values to guard against redundant DOM modifications.
+   */
+  protected lastValues_: Record<string, BindingValue> = {};
+
+  /**
+   * Main binding initialization logic. Parses each CSS variable-binding pair,
+   * retrieves the corresponding ViewModel signals, subscribes to updates,
+   * and applies the initial CSS variable state.
+   */
+  protected bindingInit_(): void {
+    DEV_MODE && this.logger_.logMethod?.('bindingInit_');
+    for (const rawPair of this.attributeValue.split(';')) {
+      const pair = rawPair.trim();
+      if (pair === '') continue;
+
+      const index = pair.indexOf(':');
+      if (index === -1) {
+        DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding_pair', {pair});
+        continue;
+      }
+      const cssVarName = pair.substring(0, index).trim();
+      const viewKey_ = pair.substring(index + 1).trim();
+      const [namespace, prop] = viewKey_.split('.');
+
+      if (!cssVarName || !namespace || !prop) {
+        DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding_pair', {pair});
+        continue;
+      }
+
+      const viewModel = service_binding.getViewModel(namespace);
+      if (!viewModel) {
+        DEV_MODE && this.logger_.accident('bindingInit_', 'missing_view_model', {namespace});
+        continue;
+      }
+
+      this.subscribe_(viewModel, (state) => {
+        const value = state[prop];
+        if (Object.is(this.lastValues_[cssVarName], value)) return; // guard against redundant updates
+        this.lastValues_[cssVarName] = value;
+        this.applyCssVar_(cssVarName, value);
+      });
+    }
+  }
+
+  /**
+   * Applies the bound value to a specific CSS variable on the element's style.
+   *
+   * @param name The name of the CSS variable (e.g., `'--player-progress'`).
+   * @param value The value to apply.
+   */
+  protected applyCssVar_(name: string, value: BindingValue): void {
+    DEV_MODE && this.logger_.logMethodArgs?.('applyCssVar_', {name, value});
+    if (value == null) {
+      this.element_.style.removeProperty(name);
+      return;
+    }
+    this.element_.style.setProperty(name, String(value));
+  }
+}
+
+/**
+ * Helper to register `BindCssVarDirective` lazily under the `bind_css_var` attribute.
+ */
+export const registerBindCssVarDirective = lazyDirective('bind_css_var', BindCssVarDirective);

--- a/pkg/nanolib/bind/src/directive_bind_text.ts
+++ b/pkg/nanolib/bind/src/directive_bind_text.ts
@@ -59,12 +59,12 @@ export class BindTextDirective extends Directive {
     DEV_MODE && this.logger_.logMethod?.('bindingInit_');
     const [namespace, prop] = this.attributeValue.trim().split('.');
     if (!namespace || !prop) {
-      this.logger_.accident?.('bindingInit_', 'invalid_binding', {namespace, prop});
+      DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding', {namespace, prop});
       return;
     }
     const viewModel = service_binding.getViewModel(namespace);
     if (!viewModel) {
-      this.logger_.accident?.('bindingInit_', 'missing_view_model', {namespace});
+      DEV_MODE && this.logger_.accident('bindingInit_', 'missing_view_model', {namespace});
       return;
     }
 

--- a/pkg/nanolib/bind/src/directive_bind_text.ts
+++ b/pkg/nanolib/bind/src/directive_bind_text.ts
@@ -11,7 +11,7 @@ import type {BindingValue} from './type.js';
  * It subscribes to the projected computed signal of the namespace and surgically updates
  * the element's `textContent` whenever the property changes.
  *
- * Supports deferred viewport initialization if the `lazy-bind` attribute is present on the element.
+ * Supports deferred viewport initialization if the `lazy_bind` attribute is present on the element.
  *
  * @example
  * ```html
@@ -19,20 +19,20 @@ import type {BindingValue} from './type.js';
  * <h2 bind_text="user.fullName">Loading...</h2>
  *
  * <!-- Lazy binding (evaluated only when element enters the viewport) -->
- * <p bind_text="article.summary" lazy-bind>Loading summary...</p>
+ * <p bind_text="article.summary" lazy_bind>Loading summary...</p>
  * ```
  */
 export class BindTextDirective extends Directive {
   /**
    * Attribute flag used to defer binding initialization until the element enters the viewport.
-   * If `lazy-bind` attribute exists, this is non-null.
+   * If `lazy_bind` attribute exists, this is non-null.
    */
-  @attribute('lazy-bind')
+  @attribute('lazy_bind')
   protected accessor lazyBinding_!: null | string;
 
   /**
    * Initializes the directive.
-   * Checks if lazy binding is enabled via `lazy-bind`.
+   * Checks if lazy binding is enabled via `lazy_bind`.
    * If yes, delegates the initialization to `lazyInit_`; otherwise, initializes immediately.
    */
   protected override init_(): void {

--- a/pkg/nanolib/bind/src/directive_bind_text.ts
+++ b/pkg/nanolib/bind/src/directive_bind_text.ts
@@ -6,7 +6,7 @@ import type {BindingValue} from './type.js';
 /**
  * A declarative DOM directive that binds an element's `textContent` to a view model property.
  *
- * Syntax: `bind-text="namespace.propertyName"`
+ * Syntax: `bind_text="namespace.propertyName"`
  *
  * It subscribes to the projected computed signal of the namespace and surgically updates
  * the element's `textContent` whenever the property changes.
@@ -16,10 +16,10 @@ import type {BindingValue} from './type.js';
  * @example
  * ```html
  * <!-- Immediate binding (default) -->
- * <h2 bind-text="user.fullName">Loading...</h2>
+ * <h2 bind_text="user.fullName">Loading...</h2>
  *
  * <!-- Lazy binding (evaluated only when element enters the viewport) -->
- * <p bind-text="article.summary" lazy-bind>Loading summary...</p>
+ * <p bind_text="article.summary" lazy-bind>Loading summary...</p>
  * ```
  */
 export class BindTextDirective extends Directive {
@@ -85,6 +85,6 @@ export class BindTextDirective extends Directive {
 }
 
 /**
- * Helper to register `BindTextDirective` lazily under the `bind-text` attribute.
+ * Helper to register `BindTextDirective` lazily under the `bind_text` attribute.
  */
-export const registerBindTextDirective = lazyDirective('bind-text', BindTextDirective);
+export const registerBindTextDirective = lazyDirective('bind_text', BindTextDirective);

--- a/pkg/nanolib/bind/src/directive_bind_value.ts
+++ b/pkg/nanolib/bind/src/directive_bind_value.ts
@@ -5,7 +5,7 @@ import {BindTextDirective} from './directive_bind_text.js';
 /**
  * A declarative DOM directive for binding input, select, and textarea element values to a view model.
  *
- * Syntax: `bind-value="namespace.propertyName"`
+ * Syntax: `bind_value="namespace.propertyName"`
  *
  * Extends `BindTextDirective`. The crucial feature of `BindValueDirective` is its DOM write guard:
  * it compares the current element value with the incoming value and only writes to the DOM
@@ -16,7 +16,7 @@ import {BindTextDirective} from './directive_bind_text.js';
  * ```html
  * <input
  *   type="text"
- *   bind-value="user.firstName"
+ *   bind_value="user.firstName"
  *   on-input="ui_edit_name:$value"
  * />
  * ```
@@ -43,6 +43,6 @@ export class BindValueDirective extends BindTextDirective {
 }
 
 /**
- * Helper to register `BindValueDirective` lazily under the `bind-value` attribute.
+ * Helper to register `BindValueDirective` lazily under the `bind_value` attribute.
  */
-export const registerBindValueDirective = lazyDirective('bind-value', BindValueDirective);
+export const registerBindValueDirective = lazyDirective('bind_value', BindValueDirective);

--- a/pkg/nanolib/bind/src/main.ts
+++ b/pkg/nanolib/bind/src/main.ts
@@ -5,6 +5,7 @@
  */
 
 import {registerBindAttribDirective} from './directive_bind_attrib.js';
+import {registerBindCssVarDirective} from './directive_bind_css_var.js';
 import {registerBindTextDirective} from './directive_bind_text.js';
 import {registerBindValueDirective} from './directive_bind_value.js';
 
@@ -15,9 +16,10 @@ export * from './type.js';
  * Bootstraps and registers all declarative binding directives in the application.
  *
  * Registers the following directives:
- * - `bind-text`: Binds DOM elements' `textContent` to a view model's property.
- * - `bind-value`: Binds input element values to a view model's property with cursor position guard.
- * - `bind-attrib`: Binds element attributes to view model properties with presence and removal support.
+ * - `bind_text`: Binds DOM elements' `textContent` to a view model's property.
+ * - `bind_value`: Binds input element values to a view model's property with cursor position guard.
+ * - `bind_attrib`: Binds element attributes to view model properties with presence and removal support.
+ * - `bind_css_var`: Binds CSS custom properties (variables) to view model properties.
  *
  * Directives are registered as lazy directives under their respective attribute names.
  *
@@ -33,4 +35,5 @@ export function setupBindDirectives(autoBootstrap: boolean): void {
   registerBindTextDirective(autoBootstrap);
   registerBindValueDirective(autoBootstrap);
   registerBindAttribDirective(autoBootstrap);
+  registerBindCssVarDirective(autoBootstrap);
 }

--- a/pkg/nanolib/bind/src/service_binding.ts
+++ b/pkg/nanolib/bind/src/service_binding.ts
@@ -63,8 +63,8 @@ class BindingService {
    * }));
    *
    * // HTML consumption:
-   * // <h2 bind-text="user.fullName"></h2>
-   * // <button bind-attrib="disabled=user.cartIsEmpty">Checkout</button>
+   * // <h2 bind_text="user.fullName"></h2>
+   * // <button bind_attrib="disabled=user.cartIsEmpty">Checkout</button>
    * ```
    */
   createViewModel<S, T extends Record<string, BindingValue>>(

--- a/pkg/nanolib/bind/src/service_binding.ts
+++ b/pkg/nanolib/bind/src/service_binding.ts
@@ -75,7 +75,7 @@ class BindingService {
     DEV_MODE && this.logger_.logMethodArgs?.('createViewModel', {namespace});
 
     if (this.viewModels_.has(namespace)) {
-      this.logger_.accident?.('createViewModel', 'duplicate_namespace_rejected', {namespace});
+      DEV_MODE && this.logger_.accident('createViewModel', 'duplicate_namespace_rejected', {namespace});
       return;
     }
 

--- a/pkg/nanolib/directive/src/decorator_directive.ts
+++ b/pkg/nanolib/directive/src/decorator_directive.ts
@@ -33,7 +33,7 @@ export function directive(name: string) {
     }
 
     if (directiveRegistry_.has(name)) {
-      logger.accident('@directive', 'duplicate_directive_registration', {name});
+      DEV_MODE && logger.accident('@directive', 'duplicate_directive_registration', {name});
       return;
     }
 

--- a/pkg/nanolib/directive/src/decorator_on.ts
+++ b/pkg/nanolib/directive/src/decorator_on.ts
@@ -47,7 +47,7 @@ export function on<D extends Directive = Directive>(
       const targetElement = selector ? this.element_.querySelector(selector) : this.element_;
 
       if (selector && targetElement === null) {
-        this.logger_.accident('on', 'selector_not_found', {selector});
+        DEV_MODE && this.logger_.accident('on', 'selector_not_found', {selector});
         return;
       }
 

--- a/pkg/nanolib/directive/src/directive_base_class.ts
+++ b/pkg/nanolib/directive/src/directive_base_class.ts
@@ -407,7 +407,7 @@ export abstract class Directive {
       element = this.element_.querySelector<HTMLElement>(element);
     }
     if (element == null) {
-      this.logger_.accident('on', 'target_not_found', {target: element});
+      DEV_MODE && this.logger_.accident('on', 'target_not_found', {target: element});
       return;
     }
 

--- a/pkg/nanolib/directive/src/lazy_directive.ts
+++ b/pkg/nanolib/directive/src/lazy_directive.ts
@@ -37,7 +37,7 @@ export function lazyDirective<T extends Directive>(
   // Return a closure — no registration happens here, only when the returned function is called.
   return function registerDirective(autoBootstrap: boolean, bootstrapRoot?: HTMLElement | Document): void {
     if (directiveRegistry_.has(name)) {
-      logger.accident('lazyDirective', 'duplicate_directive_registration', {name});
+      DEV_MODE && logger.accident('lazyDirective', 'duplicate_directive_registration', {name});
       return;
     }
     DEV_MODE && logger.logMethodArgs?.('lazyDirective', name);

--- a/pkg/nanolib/embedded-data/src/embedded-data.ts
+++ b/pkg/nanolib/embedded-data/src/embedded-data.ts
@@ -98,7 +98,7 @@ export class EmbeddedDataCollector<T> {
 
     const rawData = element.textContent;
     if (!rawData) {
-      this.logger_.accident('extractRawData_', 'element_empty', {attributeName: this.attributeName_});
+      DEV_MODE && this.logger_.accident('extractRawData_', 'element_empty', {attributeName: this.attributeName_});
       return null;
     }
 
@@ -144,10 +144,11 @@ export class EmbeddedDataCollector<T> {
 
     // Open/Closed Principle
     if (this.validator_ && !this.validator_(parsedData)) {
-      this.logger_.accident('collect', 'data_validation_failed', {
-        attributeName: this.attributeName_,
-        data: parsedData,
-      });
+      DEV_MODE
+        && this.logger_.accident('collect', 'data_validation_failed', {
+          attributeName: this.attributeName_,
+          data: parsedData,
+        });
       return null;
     }
 

--- a/pkg/nanolib/fetch/src/core.ts
+++ b/pkg/nanolib/fetch/src/core.ts
@@ -282,11 +282,11 @@ async function handleRetryPattern_(options: FetchOptions__): Promise<Response> {
 
     return response;
   } catch (err) {
-    logger_.accident('fetch', 'fetch_failed_retry', err);
+    DEV_MODE && logger_.accident('fetch', 'fetch_failed_retry', err);
 
     // Do not retry if the browser is offline.
     if (globalThis_.navigator?.onLine === false) {
-      logger_.accident('handleRetryPattern_', 'offline', 'Skip retry because offline');
+      DEV_MODE && logger_.accident('handleRetryPattern_', 'offline', 'Skip retry because offline');
       throw err;
     }
 

--- a/pkg/nanolib/page-ready/src/page-ready.ts
+++ b/pkg/nanolib/page-ready/src/page-ready.ts
@@ -147,7 +147,7 @@ export function dispatchPageReady(): void {
   const pageId = document.querySelector('[page-id]')?.getAttribute('page-id')?.trim();
 
   if (pageId == null) {
-    logger.accident('dispatchPageReady', 'page_id_not_found');
+    DEV_MODE && logger.accident('dispatchPageReady', 'page_id_not_found');
     return;
   }
 

--- a/pkg/nanolib/signal/src/core/signal-base.ts
+++ b/pkg/nanolib/signal/src/core/signal-base.ts
@@ -241,7 +241,7 @@ export abstract class SignalBase<T> {
    */
   protected checkDestroyed_(): void {
     if (this.isDestroyed__) {
-      this.logger_.accident('checkDestroyed_', 'attempt_to_use_destroyed_signal');
+      DEV_MODE && this.logger_.accident('checkDestroyed_', 'attempt_to_use_destroyed_signal');
       throw new Error(`Cannot interact with a destroyed signal (id: ${this.name})`);
     }
   }

--- a/pkg/nanotron-old/api-server/src/api-server-response.ts
+++ b/pkg/nanotron-old/api-server/src/api-server-response.ts
@@ -144,16 +144,17 @@ export class NanotronServerResponse {
 
     if (this.raw_.writableFinished && this.hasBeenSent_ === false) {
       // The response has already been sent by direct access to the server api.
-      this.logger_.accident('reply', 'server_response_writable_finished_directly');
+      DEV_MODE && this.logger_.accident('reply', 'server_response_writable_finished_directly');
       this.hasBeenSent_ = true;
     }
 
     if (this.hasBeenSent_) {
-      this.logger_.accident('reply', 'reply_already_sent', {
-        url: this.clientRequest.url.debugId,
-        replySent: this.hasBeenSent_,
-        writableFinished: this.raw_.writableFinished,
-      });
+      DEV_MODE
+        && this.logger_.accident('reply', 'reply_already_sent', {
+          url: this.clientRequest.url.debugId,
+          replySent: this.hasBeenSent_,
+          writableFinished: this.raw_.writableFinished,
+        });
       return;
     }
 

--- a/pkg/nanotron-old/api-server/src/api-server.ts
+++ b/pkg/nanotron-old/api-server/src/api-server.ts
@@ -232,10 +232,11 @@ export class NanotronApiServer {
   }
 
   protected handleClientError_(err: NodeJS.ErrnoException, socket: Duplex): void {
-    this.logger_.accident('handleClientError_', 'http_server_client_error', {
-      errCode: err.code,
-      errMessage: err.message,
-    });
+    DEV_MODE
+      && this.logger_.accident('handleClientError_', 'http_server_client_error', {
+        errCode: err.code,
+        errMessage: err.message,
+      });
 
     const errorCode = err.code?.toLowerCase() ?? `error_${HttpStatusCodes.Error_Client_400_Bad_Request}`;
     const errorMessage = err.message ?? HttpStatusMessages[HttpStatusCodes.Error_Client_400_Bad_Request];
@@ -258,7 +259,7 @@ export class NanotronApiServer {
     this.logger_.logMethod?.('handleClientRequest_');
 
     if (nativeClientRequest.url === undefined) {
-      this.logger_.accident('handleClientRequest_', 'http_server_url_undefined');
+      DEV_MODE && this.logger_.accident('handleClientRequest_', 'http_server_url_undefined');
       return;
     }
 

--- a/pkg/nitrobase-old/engine/src/alwatr-nitrobase.ts
+++ b/pkg/nitrobase-old/engine/src/alwatr-nitrobase.ts
@@ -192,7 +192,7 @@ export class AlwatrNitrobase {
     let fileStoreRef: DocumentReference | CollectionReference;
     if (stat.type === StoreFileType.Document) {
       if (data === undefined) {
-        logger.accident('newStoreFile__', 'document_data_required', stat);
+        DEV_MODE && logger.accident('newStoreFile__', 'document_data_required', stat);
         throw new Error('document_data_required', {cause: stat});
       }
       fileStoreRef = DocumentReference.newRefFromData(stat, data, this.storeChanged_);
@@ -201,12 +201,12 @@ export class AlwatrNitrobase {
       fileStoreRef = CollectionReference.newRefFromData(stat, this.storeChanged_);
     }
     else {
-      logger.accident('newStoreFile__', 'store_file_type_not_supported', stat);
+      DEV_MODE && logger.accident('newStoreFile__', 'store_file_type_not_supported', stat);
       throw new Error('store_file_type_not_supported', {cause: stat});
     }
 
     if (this.rootDb__.hasItem(fileStoreRef.id)) {
-      logger.accident('newStoreFile__', 'store_file_already_defined', stat);
+      DEV_MODE && logger.accident('newStoreFile__', 'store_file_already_defined', stat);
       throw new Error('store_file_already_defined', {cause: stat});
     }
 
@@ -241,21 +241,21 @@ export class AlwatrNitrobase {
     if (Object.hasOwn(this.cacheReferences__, id)) {
       const ref = this.cacheReferences__[id];
       if (!(ref instanceof DocumentReference)) {
-        logger.accident('openDocument', 'document_wrong_type', id);
+        DEV_MODE && logger.accident('openDocument', 'document_wrong_type', id);
         throw new Error('document_wrong_type', {cause: id});
       }
       return this.cacheReferences__[id] as unknown as DocumentReference<TDoc>;
     }
 
     if (!this.rootDb__.hasItem(id)) {
-      logger.accident('openDocument', 'document_not_found', id);
+      DEV_MODE && logger.accident('openDocument', 'document_not_found', id);
       throw new Error('document_not_found', {cause: id});
     }
 
     const storeStat = this.rootDb__.getItemData(id);
 
     if (storeStat.type != StoreFileType.Document) {
-      logger.accident('openDocument', 'document_wrong_type', id);
+      DEV_MODE && logger.accident('openDocument', 'document_wrong_type', id);
       throw new Error('document_wrong_type', {cause: id});
     }
 
@@ -290,7 +290,7 @@ export class AlwatrNitrobase {
     if (Object.hasOwn(this.cacheReferences__, id)) {
       const ref = this.cacheReferences__[id];
       if (!(ref instanceof CollectionReference)) {
-        logger.accident('openCollection', 'collection_wrong_type', id);
+        DEV_MODE && logger.accident('openCollection', 'collection_wrong_type', id);
         throw new Error('collection_wrong_type', {cause: id});
       }
       return this.cacheReferences__[id] as unknown as CollectionReference<TItem>;
@@ -298,14 +298,14 @@ export class AlwatrNitrobase {
 
     // load and create new collection reference
     if (!this.rootDb__.hasItem(id)) {
-      logger.accident('openCollection', 'collection_not_found', id);
+      DEV_MODE && logger.accident('openCollection', 'collection_not_found', id);
       throw new Error('collection_not_found', {cause: id});
     }
 
     const storeStat = this.rootDb__.getItemData(id);
 
     if (storeStat.type != StoreFileType.Collection) {
-      logger.accident('openCollection', 'collection_wrong_type', id);
+      DEV_MODE && logger.accident('openCollection', 'collection_wrong_type', id);
       throw new Error('collection_not_found', {cause: id});
     }
 
@@ -355,7 +355,7 @@ export class AlwatrNitrobase {
     const id_ = getStoreId(storeId);
     logger.logMethodArgs?.('removeStore', id_);
     if (!this.rootDb__.hasItem(id_)) {
-      logger.accident('removeStore', 'document_not_found', id_);
+      DEV_MODE && logger.accident('removeStore', 'document_not_found', id_);
       throw new Error('document_not_found', {cause: id_});
     }
     const ref = this.cacheReferences__[id_];

--- a/pkg/nitrobase-old/reference/src/collection-reference.ts
+++ b/pkg/nitrobase-old/reference/src/collection-reference.ts
@@ -93,22 +93,22 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
     this.logger__.logMethod?.('validateContext__');
 
     if (this.context__.ok !== true) {
-      this.logger__.accident?.('validateContext__', 'store_not_ok');
+      DEV_MODE && this.logger__.accident('validateContext__', 'store_not_ok');
       throw new Error('store_not_ok', {cause: {context: this.context__}});
     }
 
     if (this.context__.meta === undefined) {
-      this.logger__.accident?.('validateContext__', 'store_meta_undefined');
+      DEV_MODE && this.logger__.accident('validateContext__', 'store_meta_undefined');
       throw new Error('store_meta_undefined', {cause: {context: this.context__}});
     }
 
     if (this.context__.meta.type !== StoreFileType.Collection) {
-      this.logger__.accident?.('validateContext__', 'collection_type_invalid', this.context__.meta);
+      DEV_MODE && this.logger__.accident('validateContext__', 'collection_type_invalid', this.context__.meta);
       throw new Error('collection_type_invalid', {cause: this.context__.meta});
     }
 
     if (this.context__.meta.fv !== CollectionReference.fileFormatVersion) {
-      this.logger__.incident?.('validateContext__', 'store_file_version_incompatible', {
+      DEV_MODE && this.logger__.incident?.('validateContext__', 'store_file_version_incompatible', {
         old: this.context__.meta.fv,
         new: CollectionReference.fileFormatVersion,
       });
@@ -125,7 +125,7 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
     this.logger__.logMethod?.('migrateContext__');
 
     if (this.context__.meta.fv > CollectionReference.fileFormatVersion) {
-      this.logger__.accident('migrateContext__', 'store_version_incompatible', this.context__.meta);
+      DEV_MODE && this.logger__.accident('migrateContext__', 'store_version_incompatible', this.context__.meta);
       throw new Error('store_version_incompatible', {cause: this.context__.meta});
     }
 
@@ -296,7 +296,7 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
   private item__(itemId: string | number): CollectionItem<TItem> {
     const item = this.context__.data[itemId];
     if (item === undefined) {
-      this.logger__.accident('item__', 'collection_item_not_found', {itemId});
+      DEV_MODE && this.logger__.accident('item__', 'collection_item_not_found', {itemId});
       throw new Error('collection_item_not_found', {cause: {itemId}});
     }
     return item;
@@ -367,7 +367,7 @@ export class CollectionReference<TItem extends JsonObject = JsonObject> {
   public addItem(itemId: string | number, data: TItem): void {
     this.logger__.logMethodArgs?.('addItem', {itemId, data});
     if (this.hasItem(itemId)) {
-      this.logger__.accident('addItem', 'collection_item_exist', {itemId});
+      DEV_MODE && this.logger__.accident('addItem', 'collection_item_exist', {itemId});
       throw new Error('collection_item_exist', {cause: {itemId}});
     }
 

--- a/pkg/nitrobase-old/reference/src/document-reference.ts
+++ b/pkg/nitrobase-old/reference/src/document-reference.ts
@@ -83,17 +83,17 @@ export class DocumentReference<TDoc extends JsonObject = JsonObject> {
     this.logger__.logMethod?.('validateContext__');
 
     if (this.context__.ok !== true) {
-      this.logger__.accident?.('validateContext__', 'store_not_ok');
+      DEV_MODE && this.logger__.accident('validateContext__', 'store_not_ok');
       throw new Error('store_not_ok', {cause: {context: this.context__}});
     }
 
     if (this.context__.meta === undefined) {
-      this.logger__.accident?.('validateContext__', 'store_meta_undefined');
+      DEV_MODE && this.logger__.accident('validateContext__', 'store_meta_undefined');
       throw new Error('store_meta_undefined', {cause: {context: this.context__}});
     }
 
     if (this.context__.meta.type !== StoreFileType.Document) {
-      this.logger__.accident?.('validateContext__', 'document_type_invalid', this.context__.meta);
+      DEV_MODE && this.logger__.accident('validateContext__', 'document_type_invalid', this.context__.meta);
       throw new Error('document_type_invalid', {cause: this.context__.meta});
     }
 
@@ -115,7 +115,7 @@ export class DocumentReference<TDoc extends JsonObject = JsonObject> {
     this.logger__.logMethod?.('migrateContext__');
 
     if (this.context__.meta.fv > DocumentReference.fileFormatVersion) {
-      this.logger__.accident('migrateContext__', 'store_version_incompatible', this.context__.meta);
+      DEV_MODE && this.logger__.accident('migrateContext__', 'store_version_incompatible', this.context__.meta);
       throw new Error('store_version_incompatible', {cause: this.context__.meta});
     }
 

--- a/pkg/nitrobase-old/user-management/src/user-management.ts
+++ b/pkg/nitrobase-old/user-management/src/user-management.ts
@@ -199,7 +199,7 @@ export class NitrobaseUserManagement<TUser extends JsonObject> implements Nitrob
       ownerId: userId,
     };
     if (this.nitrobase_.hasStore(storeId)) {
-      this.logger_.accident?.('newUserInfoDocument_', 'store_already_exists', storeId);
+      DEV_MODE && this.logger_.accident('newUserInfoDocument_', 'store_already_exists', storeId);
       return;
     }
     this.nitrobase_.newDocument<TUser>(storeId, userInfo);


### PR DESCRIPTION
## Description

Enhance the `subscribeAll` method by making action listeners optional. Refactor binding syntax for consistency across the application, updating from 'bind-*' to 'bind_*'. Introduce `BindCssVarDirective` for binding CSS custom properties and add support for internal and external transitions with action effects in the finite state machine. Improve documentation for clarity and conditionally log accidents in development mode for better debugging.

