### PR TITLE
Add support for negated attributes in BindAttribDirective

### DIFF
--- a/pkg/nanolib/bind/README.md
+++ b/pkg/nanolib/bind/README.md
@@ -23,6 +23,7 @@ In traditional modern frameworks, updating state triggers virtual DOM reconcilia
 - 🛡️ **Cursor Preservation Guard (`bind_value`)**: Binds input element values securely, checking for changes before writing to the DOM. This guards against the browser resetting the text cursor position while typing in an input field.
 - 💡 **Presence-Aware Attribute Binding (`bind_attrib`)**:
   - `boolean` values toggle the _presence_ of the attribute (perfect for `disabled`, `checked`, `hidden`).
+  - Negation prefix `!` (e.g. `!player.isPlaying`) negates the value.
   - `null`/`undefined` values _remove_ the attribute from the DOM.
   - Primitive values set the attribute value as a string.
 - 💤 **Lazy Viewport Evaluation (`lazy_bind`)**: Defer binding registration and signal subscription until the element physically enters the viewport (using `IntersectionObserver` via `@alwatr/directive`). This is ideal for off-screen cards, slow-loading inputs, or heavy dashboard elements.
@@ -157,13 +158,15 @@ if (inputEl.value !== nextValue) {
 
 This ensures that user input typing feels smooth and the text cursor does not reset or jump to the end of the input field.
 
-### `bind_attrib="attr1=namespace.prop1; attr2=namespace.prop2"`
+### `bind_attrib="attr1=[!]namespace.prop1; attr2=[!]namespace.prop2"`
 
 Binds element attributes to ViewModel properties. Multiple attributes are semicolon-separated.
 
 - **Boolean values**:
   - `true`: Sets the attribute with an empty string value (e.g., `disabled=""`).
   - `false`: Removes the attribute entirely from the element.
+- **Negation prefix (`!`)**:
+  - Prefixing the property with `!` (e.g., `hidden=!player.isPlaying`) negates the value (coerced as boolean) before applying.
 - **Nullish values (`null`/`undefined`)**: Removes the attribute entirely.
 - **Other values**: Sets the attribute value coerced as a string.
 

--- a/pkg/nanolib/bind/src/directive_bind_attrib.test.js
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.test.js
@@ -1,0 +1,70 @@
+// Define DEV_MODE globally so that TS source files can run directly in bun test
+globalThis.DEV_MODE = true;
+
+import {describe, it, expect, beforeEach, afterEach} from 'bun:test';
+import {GlobalRegistrator} from '@happy-dom/global-registrator';
+import {createStateSignal} from '@alwatr/signal';
+import {bootstrapDirectives} from '@alwatr/directive';
+import {service_binding, setupBindDirectives} from './main.js';
+
+// Register DOM globals if not already done (guard against double-registration)
+if (typeof document === 'undefined') {
+  GlobalRegistrator.register();
+}
+
+/** Wait for the constructor's IIFE and microtasks to complete */
+const waitForInit = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+describe('BindAttribDirective', () => {
+  let signal;
+
+  beforeEach(() => {
+    // Ensure all directives are registered
+    setupBindDirectives(true);
+    signal = createStateSignal({
+      name: 'test-player-signal-attrib',
+      initialValue: {
+        isPlaying: true,
+        volume: 80,
+        muted: false,
+      },
+    });
+    service_binding.createViewModel('player', signal, (s) => ({
+      isPlaying: s.isPlaying,
+      volume: s.volume,
+      muted: s.muted,
+    }));
+  });
+
+  afterEach(() => {
+    service_binding.removeViewModel('player');
+    document.body.innerHTML = '';
+  });
+
+  it('should bind normal and negated attributes to element', async () => {
+    const el = document.createElement('div');
+    // hidden should be !isPlaying (negated)
+    // data-volume should be volume (normal)
+    // disabled should be muted (normal)
+    el.setAttribute('bind_attrib', 'hidden=!player.isPlaying; data-volume=player.volume; disabled=player.muted');
+    document.body.appendChild(el);
+
+    // Bootstrap directives on the page
+    bootstrapDirectives();
+    await waitForInit();
+
+    // Since isPlaying is true, !isPlaying is false. So hidden should NOT be present.
+    expect(el.hasAttribute('hidden')).toBe(false);
+    expect(el.getAttribute('data-volume')).toBe('80');
+    expect(el.hasAttribute('disabled')).toBe(false);
+
+    // Update state to isPlaying=false, muted=true
+    signal.set({isPlaying: false, volume: 50, muted: true});
+    await waitForInit();
+
+    // Since isPlaying is false, !isPlaying is true. So hidden should be present.
+    expect(el.hasAttribute('hidden')).toBe(true);
+    expect(el.getAttribute('data-volume')).toBe('50');
+    expect(el.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/pkg/nanolib/bind/src/directive_bind_attrib.test.js
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.test.js
@@ -67,4 +67,25 @@ describe('BindAttribDirective', () => {
     expect(el.getAttribute('data-volume')).toBe('50');
     expect(el.hasAttribute('disabled')).toBe(true);
   });
+
+  it('should tolerate whitespaces around equal signs and semicolons', async () => {
+    const el = document.createElement('div');
+    el.setAttribute('bind_attrib', '  hidden  =  !  player.isPlaying  ;   data-volume   =   player.volume  ; disabled = player.muted ');
+    document.body.appendChild(el);
+
+    bootstrapDirectives();
+    await waitForInit();
+
+    expect(el.hasAttribute('hidden')).toBe(false);
+    expect(el.getAttribute('data-volume')).toBe('80');
+    expect(el.hasAttribute('disabled')).toBe(false);
+
+    // Update state to isPlaying=false, muted=true
+    signal.set({isPlaying: false, volume: 55, muted: true});
+    await waitForInit();
+
+    expect(el.hasAttribute('hidden')).toBe(true);
+    expect(el.getAttribute('data-volume')).toBe('55');
+    expect(el.hasAttribute('disabled')).toBe(true);
+  });
 });

--- a/pkg/nanolib/bind/src/directive_bind_attrib.test.js
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.test.js
@@ -1,11 +1,8 @@
-// Define DEV_MODE globally so that TS source files can run directly in bun test
-globalThis.DEV_MODE = true;
-
 import {describe, it, expect, beforeEach, afterEach} from 'bun:test';
 import {GlobalRegistrator} from '@happy-dom/global-registrator';
 import {createStateSignal} from '@alwatr/signal';
 import {bootstrapDirectives} from '@alwatr/directive';
-import {service_binding, setupBindDirectives} from './main.js';
+import {service_binding, setupBindDirectives} from '@alwatr/bind';
 
 // Register DOM globals if not already done (guard against double-registration)
 if (typeof document === 'undefined') {
@@ -70,7 +67,10 @@ describe('BindAttribDirective', () => {
 
   it('should tolerate whitespaces around equal signs and semicolons', async () => {
     const el = document.createElement('div');
-    el.setAttribute('bind_attrib', '  hidden  =  !  player.isPlaying  ;   data-volume   =   player.volume  ; disabled = player.muted ');
+    el.setAttribute(
+      'bind_attrib',
+      '  hidden  =  !  player.isPlaying  ;   data-volume   =   player.volume  ; disabled = player.muted ',
+    );
     document.body.appendChild(el);
 
     bootstrapDirectives();

--- a/pkg/nanolib/bind/src/directive_bind_attrib.ts
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.ts
@@ -98,10 +98,7 @@ export class BindAttribDirective extends Directive {
       }
 
       this.subscribe_(viewModel, (state) => {
-        let value = state[prop];
-        if (isNot) {
-          value = !value;
-        }
+        const value = isNot ? !state[prop] : state[prop];
         if (Object.is(this.lastValues_[attributeName], value)) return; // guard against redundant updates
         this.lastValues_[attributeName] = value;
         this.applyAttribute_(attributeName, value);

--- a/pkg/nanolib/bind/src/directive_bind_attrib.ts
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.ts
@@ -5,13 +5,14 @@ import {service_binding, type BindingValue} from './main.js';
 /**
  * A declarative DOM directive that binds DOM element attributes to view model properties.
  *
- * Syntax: `bind_attrib="attributeName=namespace.propertyName; anotherAttribute=namespace.anotherProperty"`
+ * Syntax: `bind_attrib="attributeName=[!]namespace.propertyName; anotherAttribute=[!]namespace.anotherProperty"`
  *
  * Supports binding multiple attributes on the same element separated by semicolons (`;`).
  *
  * Behavior:
  * - `boolean` value: Toggles the presence of the attribute (idiomatic for boolean attributes like `disabled`, `hidden`, `readonly`, `checked`).
  * - `null` / `undefined` value: Removes the attribute from the element.
+ * - Negation (`!`): Prefixing the property with `!` (e.g., `!namespace.prop`) will negate the value (coerced as boolean).
  * - Any other type: Coerced via `String(value)` and set as the attribute's value.
  *
  * Includes a redundant write guard (via `lastValues_`) that skips calls to the DOM if the property value hasn't changed.
@@ -21,6 +22,9 @@ import {service_binding, type BindingValue} from './main.js';
  * ```html
  * <!-- Binds presence of 'disabled' to cart emptiness and 'aria-busy' to loading state -->
  * <button bind_attrib="disabled=user.cartIsEmpty; aria-busy=ui.loading">Checkout</button>
+ *
+ * <!-- Binds 'hidden' to the negation of isPlaying -->
+ * <div bind_attrib="hidden=!player.isPlaying">Player is paused</div>
  *
  * <!-- Binds 'src' and 'alt' attributes -->
  * <img bind_attrib="src=user.avatarUrl; alt=user.fullName" />

--- a/pkg/nanolib/bind/src/directive_bind_attrib.ts
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.ts
@@ -68,7 +68,10 @@ export class BindAttribDirective extends Directive {
       if (pair === '') continue;
 
       const [attributeName, viewKey_ = ''] = pair.split('=');
-      const [namespace, prop] = viewKey_.split('.');
+      const isNot = viewKey_.startsWith('!');
+      const cleanViewKey = isNot ? viewKey_.slice(1) : viewKey_;
+      const [namespace, prop] = cleanViewKey.split('.');
+
       if (!attributeName || !namespace || !prop) {
         DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding_pair', {pair});
         continue;
@@ -81,7 +84,10 @@ export class BindAttribDirective extends Directive {
       }
 
       this.subscribe_(viewModel, (state) => {
-        const value = state[prop];
+        let value = state[prop];
+        if (isNot) {
+          value = !value;
+        }
         if (Object.is(this.lastValues_[attributeName], value)) return; // guard against redundant updates
         this.lastValues_[attributeName] = value;
         this.applyAttribute_(attributeName, value);

--- a/pkg/nanolib/bind/src/directive_bind_attrib.ts
+++ b/pkg/nanolib/bind/src/directive_bind_attrib.ts
@@ -71,12 +71,22 @@ export class BindAttribDirective extends Directive {
       const pair = rawPair.trim();
       if (pair === '') continue;
 
-      const [attributeName, viewKey_ = ''] = pair.split('=');
-      const isNot = viewKey_.startsWith('!');
-      const cleanViewKey = isNot ? viewKey_.slice(1) : viewKey_;
-      const [namespace, prop] = cleanViewKey.split('.');
+      const [rawAttributeName = '', rawViewKey = ''] = pair.split('=');
+      const attributeName = rawAttributeName.trim();
+      const viewKey_ = rawViewKey.trim();
 
-      if (!attributeName || !namespace || !prop) {
+      if (attributeName === '' || viewKey_ === '') {
+        DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding_pair', {pair});
+        continue;
+      }
+
+      const isNot = viewKey_.startsWith('!');
+      const cleanViewKey = isNot ? viewKey_.slice(1).trim() : viewKey_;
+      const [rawNamespace = '', rawProp = ''] = cleanViewKey.split('.');
+      const namespace = rawNamespace.trim();
+      const prop = rawProp.trim();
+
+      if (namespace === '' || prop === '') {
         DEV_MODE && this.logger_.accident('bindingInit_', 'invalid_binding_pair', {pair});
         continue;
       }

--- a/pkg/nanolib/bind/src/directive_bind_css_var.test.js
+++ b/pkg/nanolib/bind/src/directive_bind_css_var.test.js
@@ -1,11 +1,8 @@
-// Define DEV_MODE globally so that TS source files can run directly in bun test
-globalThis.DEV_MODE = true;
-
 import {describe, it, expect, beforeEach, afterEach} from 'bun:test';
 import {GlobalRegistrator} from '@happy-dom/global-registrator';
 import {createStateSignal} from '@alwatr/signal';
 import {bootstrapDirectives} from '@alwatr/directive';
-import {service_binding, setupBindDirectives} from './main.js';
+import {service_binding, setupBindDirectives} from '@alwatr/bind';
 
 // Register DOM globals if not already done (guard against double-registration)
 if (typeof document === 'undefined') {


### PR DESCRIPTION
## Description

Add support for negation in presence-aware attribute binding, allowing attributes to be negated using a prefix. This enhances the flexibility of the `bind_attrib` directive by enabling the binding of negated boolean values. Documentation updates reflect this new feature.

