### PR TITLE
feat(flux): add createListDirective factory for zero-boilerplate dynamic lists

### DIFF
--- a/pkg/flux/README.md
+++ b/pkg/flux/README.md
@@ -435,6 +435,48 @@ In your HTML, bind properties using declarative attributes:
 
 ---
 
+### 📋 **Dynamic List Rendering (Zero-Boilerplate)**
+
+`@alwatr/bind` is intentionally limited to **surgical, flat-primitive** updates on _existing_ elements — it never creates, removes, or reorders DOM subtrees. The moment a list's cardinality changes at runtime (add / remove / reorder), you need keyed reconciliation, which is `lit-html`'s `repeat`.
+
+Doing that by hand means writing a `LitDirective` subclass per list: a `@state` accessor, an `init_()` that subscribes to the signal, and a `render_()` that calls `repeat(...)`. The only parts that ever change are the **signal**, the **key function**, and the **row template**. `createListDirective` captures exactly those three and hands you a ready-to-register directive — no per-list class:
+
+```typescript
+// directive/shop-list.ts — definition (zero side effects on import)
+import {createListDirective, html} from '@alwatr/flux';
+import {state_shop_list} from '../domain/state_shop_list.js';
+
+export const registerShopListDirective = createListDirective({
+  name: 'shop_list',
+  source: () => state_shop_list.instance, // thunk → preserves lazy `.instance`
+  key: (shop) => shop.meta.id, // stable identity for keyed reconciliation
+  row: (shop) => html`
+    <li on-click="ui_shop_clicked:${shop.meta.id}">${shop.content.title}</li>
+  `,
+  empty: () => html`<p class="muted">No shops to display.</p>`,
+});
+```
+
+```typescript
+// bootstrap.ts — registration (the only side effect)
+registerShopListDirective(true);
+```
+
+```html
+<!-- view — the whole list, surgically reconciled, with zero per-list code -->
+<ul shop_list></ul>
+```
+
+#### 🌟 Key Advantages
+
+- **No per-list boilerplate**: The repetitive subscribe / `@state` / `render_` cycle collapses into one config object.
+- **Keyed reconciliation under the hood**: Built on `lit-html`'s `repeat`, so only the rows whose key changed are created, removed, or moved — preserving focus, input state, scroll, and CSS transitions across reorders.
+- **Full row power**: Because `row` is a `lit-html` template function, per-row dynamic action payloads (`on-click="…:${item.id}"`), nested templates, and conditional structure all work.
+- **Headless & UDF-pure**: Ships no markup or styling tokens; data flows down from the source signal, intents fire up via `on-<event>` delegation. The directive never owns or mutates state.
+- **Tree-shakeable**: The `source` thunk is resolved inside `init_()`, never at import time, so the module has no import-time side effects and the signal's lazy `.instance` guarantee is honored.
+
+---
+
 ### 🤖 **Finite State Machine (FSM) & Actor Model**
 
 Flux natively aggregates `@alwatr/fsm` to eliminate ad-hoc state variables, boolean flags, and race conditions. Instead of writing unpredictable, disjointed spaghetti code, you model your application's lifecycle as a **declarative, type-safe statechart**.
@@ -1456,6 +1498,73 @@ const status = (isLoading: boolean) => html`
   </div>
 `;
 ```
+
+#### `repeat(items, keyFn, template)`
+
+Keyed list rendering. Unlike mapping an array directly (which re-renders by index), `repeat` uses the key returned by `keyFn` to **move** existing DOM rows on reorder instead of recreating them — preserving focus, input state, and CSS transitions.
+
+```typescript
+import {html, repeat} from '@alwatr/flux';
+
+const list = (items: {id: number; title: string}[]) => html`
+  <ul>
+    ${repeat(
+      items,
+      (item) => item.id, // stable key (never the array index for a mutable list)
+      (item) => html`
+        <li>${item.title}</li>
+      `,
+    )}
+  </ul>
+`;
+```
+
+> For a fully wired, signal-bound list with no per-list boilerplate, prefer [`createListDirective`](#dynamic-list-directive-createlistdirective), which builds on `repeat`.
+
+---
+
+### Dynamic List Directive (`createListDirective`)
+
+A factory that turns the repetitive "subscribe to a list signal and render its rows with `repeat`" pattern into a single declarative configuration object. Returns a registration function with the same contract as `lazyDirective`'s output.
+
+#### `createListDirective(config)`
+
+| Config field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Attribute that activates the directive (e.g. `'shop_list'` → `<ul shop_list>`). Must be unique. |
+| `source` | `() => IReadonlySignal<readonly T[]>` | **Thunk** returning the source list signal. Invoked inside `init_()` so the signal's lazy `.instance` is preserved and the module stays side-effect-free at import. |
+| `key` | `KeyFn<T>` | Stable, unique identity per item for keyed reconciliation. Never the array index for a mutable list. |
+| `row` | `ItemTemplate<T>` | `lit-html` template for a single row. Supports per-row action payloads, nested templates, and conditionals. |
+| `empty?` | `() => unknown` | Optional template rendered when the list is empty. Omit to render nothing. |
+
+```typescript
+import {createListDirective, html} from '@alwatr/flux';
+import {state_basket_items} from '../domain/state_basket_items.js';
+
+export const registerBasketItemsDirective = createListDirective({
+  name: 'basket_items',
+  source: () => state_basket_items.instance,
+  key: (item) => item.id,
+  row: (item) => html`
+    <li class="basket-row">
+      <span>${item.title}</span>
+      <button on-click="ui_remove_item:${item.id}">remove</button>
+    </li>
+  `,
+  empty: () => html`<p class="muted">Your basket is empty.</p>`,
+});
+
+// Bootstrap phase — registers the directive (only side effect):
+registerBasketItemsDirective(true);
+```
+
+```html
+<ul basket_items></ul>
+```
+
+**Behavior:** subscribes to `source()` on `init_()`, mirrors the array, and on every emission re-runs `repeat(items, key, row)` through a batched `LitDirective` update. When the array is empty and `empty` is provided, the empty template is rendered instead. The subscription auto-unsubscribes when the directive is destroyed (e.g. `bfcache` teardown).
+
+**When _not_ to use it:** if the set of rows is fixed and only per-row fields or visibility change, prefer `@alwatr/bind` (`bind_text` / `bind_attrib` with `?hidden`) — it skips reconciliation entirely and is cheaper.
 
 ---
 

--- a/pkg/flux/src/list-directive.ts
+++ b/pkg/flux/src/list-directive.ts
@@ -155,7 +155,9 @@ export function createListDirective<T>(config: ListDirectiveConfig<T>): Register
       // The signal invokes the callback immediately with its current value, so the first render is
       // scheduled right after `init_()` — no separate priming step needed.
       this.subscribe_(source(), (items) => {
-        this.items_ = items ?? [];
+        // Defensive guard: a hydrated/serialized source (e.g. EmbeddedDataCollector JSON) could
+        // yield a non-array; fall back to an empty list so `length` and `repeat` never throw.
+        this.items_ = Array.isArray(items) ? items : [];
         this.requestUpdate(); // batched: collapses to a single render_() per macrotask
       });
     }

--- a/pkg/flux/src/list-directive.ts
+++ b/pkg/flux/src/list-directive.ts
@@ -1,0 +1,173 @@
+/**
+ * @package @alwatr/flux
+ *
+ * `createListDirective` — a factory that turns the repetitive "subscribe to a list signal and
+ * render its rows" pattern into a single declarative configuration object.
+ *
+ * ### Why this exists
+ *
+ * Rendering a dynamic list the manual way means writing a dedicated `LitDirective` subclass for
+ * every list: a `@state` accessor, an `init_()` that subscribes to the source signal, and a
+ * `render_()` that calls `repeat(...)`. That boilerplate is identical from list to list — only
+ * the signal, the key function, and the row template ever change.
+ *
+ * `createListDirective` captures exactly those three moving parts in a config object and returns
+ * a ready-to-register lazy directive. Under the hood it still uses `lit-html`'s keyed `repeat`,
+ * so you get battle-tested, surgical, keyed reconciliation (create / remove / move only the rows
+ * that actually changed) with zero per-list code.
+ *
+ * ### How it fits the Alwatr architecture
+ *
+ * - **Headless infrastructure** — the factory ships no markup and no styling tokens; the App layer
+ *   supplies the row template (a `lit-html` `html` result). It is a portal mechanism, not a view.
+ * - **Unidirectional data flow** — data flows down from the source signal into the rows; rows fire
+ *   intents up through the usual `on-<event>` ActionService delegation (e.g.
+ *   `on-click="ui_item_clicked:${item.id}"`). The directive never owns or mutates state.
+ * - **Tree-shaking & lazy signals** — the source is provided as a *thunk* (`() => signal.instance`),
+ *   never an eagerly-resolved signal. The thunk is invoked inside `init_()`, so the signal's lazy
+ *   `.instance` evaluation guarantee is preserved and importing this module triggers no side effects.
+ */
+
+import {LitDirective, lazyDirective, type RegisterDirectiveFunction} from '@alwatr/directive';
+import type {IReadonlySignal} from '@alwatr/signal';
+
+import {repeat, type ItemTemplate, type KeyFn} from './lit-html.js';
+
+/**
+ * Declarative configuration for a dynamic list directive.
+ *
+ * @template T The shape of a single list item (the element type of the source array).
+ */
+export interface ListDirectiveConfig<T> {
+  /**
+   * The attribute name that activates the directive on an element (e.g. `'shop_list'` for
+   * `<ul shop_list></ul>`). Must be unique across all registered directives.
+   */
+  name: string;
+
+  /**
+   * A thunk that returns the source signal holding the list.
+   *
+   * Provided as a function — not the signal itself — so the signal is resolved lazily inside the
+   * directive's `init_()` rather than at module-import time. This preserves the `lazy().instance`
+   * evaluation guarantee and keeps the module free of import-time side effects.
+   *
+   * @example
+   * ```ts
+   * source: () => state_shop_list.instance,
+   * ```
+   */
+  source: () => IReadonlySignal<readonly T[]>;
+
+  /**
+   * Returns a stable, unique identity for an item, used by `repeat` for keyed reconciliation.
+   *
+   * A correct key is what lets the directive *move* an existing DOM row instead of destroying and
+   * recreating it — preserving focus, input state, scroll position, and CSS transitions across
+   * reorders. Never key by array index for a mutable list.
+   *
+   * @example
+   * ```ts
+   * key: (shop) => shop.meta.id,
+   * ```
+   */
+  key: KeyFn<T>;
+
+  /**
+   * Returns the `lit-html` template for a single row.
+   *
+   * Receives the item and its current index. Because it is a full `lit-html` template function it
+   * supports per-row dynamic action payloads, nested templates, and conditional structure.
+   *
+   * @example
+   * ```ts
+   * row: (shop) => html`
+   *   <li on-click="ui_shop_clicked:${shop.meta.id}">${shop.content.title}</li>
+   * `,
+   * ```
+   */
+  row: ItemTemplate<T>;
+
+  /**
+   * Optional template rendered when the list is empty. When omitted, an empty list renders nothing.
+   *
+   * @example
+   * ```ts
+   * empty: () => html`<p class="muted">No items yet.</p>`,
+   * ```
+   */
+  empty?: () => unknown;
+}
+
+/**
+ * Creates a registerable, dynamic list directive from a declarative configuration.
+ *
+ * The returned function follows the same contract as {@link lazyDirective}'s output: calling it
+ * registers the directive (and, when `autoBootstrap` is `true`, immediately initializes every
+ * matching element on the page). Registration is the only side effect — defining the directive
+ * via this factory does nothing until the returned function is invoked during bootstrap.
+ *
+ * @template T The shape of a single list item.
+ * @param config The list directive configuration (name, source thunk, key, row template, empty template).
+ * @returns A registration function: `(autoBootstrap, bootstrapRoot?) => void`.
+ *
+ * @example — Define once, use declaratively
+ * ```ts
+ * // directive/shop-list.ts — definition (zero side effects on import)
+ * import {createListDirective, html} from '@alwatr/flux';
+ * import {state_shop_list} from '../domain/state_shop_list.js';
+ *
+ * export const registerShopListDirective = createListDirective({
+ *   name: 'shop_list',
+ *   source: () => state_shop_list.instance,
+ *   key: (shop) => shop.meta.id,
+ *   row: (shop) => html`
+ *     <li on-click="ui_shop_clicked:${shop.meta.id}">${shop.content.title}</li>
+ *   `,
+ *   empty: () => html`<p class="muted">No shops to display.</p>`,
+ * });
+ * ```
+ *
+ * ```ts
+ * // bootstrap.ts — registration
+ * registerShopListDirective(true);
+ * ```
+ *
+ * ```html
+ * <!-- view — the whole list, surgically reconciled, with no per-list directive code -->
+ * <ul shop_list></ul>
+ * ```
+ */
+export function createListDirective<T>(config: ListDirectiveConfig<T>): RegisterDirectiveFunction {
+  const {name, source, key, row, empty} = config;
+
+  /**
+   * Anonymous `LitDirective` specialized for this one list. Captures `source`, `key`, `row`, and
+   * `empty` from the enclosing factory scope, so no per-list subclass needs to be authored.
+   */
+  class ListDirective extends LitDirective {
+    /** The latest snapshot of the list, mirrored from the source signal. */
+    protected items_: readonly T[] = [];
+
+    protected override init_(): void {
+      // Resolve the signal lazily here (not at factory-call or import time) to honor the
+      // `lazy().instance` contract. `subscribe_` auto-unsubscribes when the directive is destroyed.
+      // The signal invokes the callback immediately with its current value, so the first render is
+      // scheduled right after `init_()` — no separate priming step needed.
+      this.subscribe_(source(), (items) => {
+        this.items_ = items ?? [];
+        this.requestUpdate(); // batched: collapses to a single render_() per macrotask
+      });
+    }
+
+    protected override render_(): unknown {
+      if (this.items_.length === 0 && empty !== undefined) {
+        return empty();
+      }
+      // Keyed reconciliation: lit-html moves/creates/removes only the rows whose key changed.
+      return repeat(this.items_, key, row);
+    }
+  }
+
+  return lazyDirective(name, ListDirective);
+}

--- a/pkg/flux/src/main.ts
+++ b/pkg/flux/src/main.ts
@@ -13,3 +13,4 @@ export * from '@alwatr/local-storage';
 export * from '@alwatr/session-storage';
 export * from '@alwatr/page-ready';
 export * from './lit-html.js';
+export * from './list-directive.js';

--- a/pkg/nanolib/bind/README.md
+++ b/pkg/nanolib/bind/README.md
@@ -176,6 +176,19 @@ When placed alongside any of the above binding attributes, the directive delays 
 
 ---
 
+## 📐 Scope & Boundaries (Dynamic Lists)
+
+`@alwatr/bind` performs **surgical, flat-primitive** updates on _elements that already exist_ in the DOM. It deliberately does **not** create, remove, or reorder element subtrees, and it has **no keyed reconciliation** — so it is not the tool for rendering a list whose number of rows changes at runtime.
+
+Pick the right tool by how the list changes:
+
+- **Row set is fixed; only per-row fields or visibility change** → stay in `@alwatr/bind`. Bind each row's nodes with `bind_text` / `bind_attrib` and filter with `?hidden` (no reconciliation at all — the cheapest path).
+- **Cardinality changes at runtime (add / remove / reorder)** → use [`createListDirective`](https://github.com/Alwatr/alwatr/tree/next/pkg/flux#dynamic-list-directive-createlistdirective) from `@alwatr/flux`. It wraps `lit-html`'s keyed `repeat` in a zero-boilerplate factory, so you configure a `source` signal, a `key`, and a `row` template instead of hand-writing a directive per list.
+
+This keeps `@alwatr/bind` minimal and focused: reaching for a `bind_repeat` here would mean reimplementing a reconciliation engine that `lit-html` already provides.
+
+---
+
 ## 📄 License
 
 Licensed under the **MPL-2.0** License.


### PR DESCRIPTION
## Summary

Adds **`createListDirective`** to `@alwatr/flux` — a factory that collapses the repetitive "subscribe to a list signal and render its rows with `lit-html` `repeat`" boilerplate into a single declarative configuration object.

Motivation: rendering a dynamic list the manual way means writing a dedicated `LitDirective` subclass per list (`@state` accessor + `init_()` subscription + `render_()` calling `repeat(...)`). The only parts that ever change are the **signal**, the **key**, and the **row template**. This factory captures exactly those three and returns a ready-to-register lazy directive.

This is the chosen design (**Path B**) after evaluating the alternatives:
- ❌ Bringing in Preact (second VDOM runtime, fights the ActionService/no-per-element-listener model).
- ❌ Building a `bind_repeat` in `@alwatr/bind` (would reimplement keyed reconciliation that `lit-html` already provides; `bind` is intentionally for flat, surgical primitive updates).
- ✅ A thin factory over `lit-html`'s proven keyed `repeat`, living in `flux` (which already bundles `lit-html` + `directive` + `signal`).

## Changes

- **`pkg/flux/src/list-directive.ts`** (new) — `createListDirective(config)` + `ListDirectiveConfig<T>`, fully JSDoc-documented.
- **`pkg/flux/src/main.ts`** — export the new module.
- **`pkg/flux/README.md`** — Key Features section, a `repeat` entry in the Template section, and a full API reference for `createListDirective`.
- **`pkg/nanolib/bind/README.md`** — a Scope & Boundaries note clarifying that dynamic lists belong to `createListDirective`, not `bind`.

## Design notes

- **Lazy & side-effect free** — `source` is a thunk (`() => signal.instance`) resolved inside `init_()`, preserving the `lazy().instance` guarantee; importing the module triggers nothing.
- **Keyed reconciliation** — built on `lit-html`'s `repeat`, so only changed rows are created/removed/moved (focus, input state, scroll, and transitions survive reorders).
- **Headless & UDF-pure** — ships no markup or styling tokens; the App layer supplies the `row` template; intents fire up via `on-<event>` delegation; the directive never owns or mutates state.
- **Auto-cleanup** — the subscription unsubscribes on directive destroy (e.g. `bfcache` teardown).

## Verification

- `lerna run build:ts --scope @alwatr/flux --include-dependencies` ✅ (19 packages, `noEmitOnError` — `dist/list-directive.d.ts` emitted cleanly).

## Usage

```ts
export const registerShopListDirective = createListDirective({
  name: 'shop_list',
  source: () => state_shop_list.instance,
  key: (shop) => shop.meta.id,
  row: (shop) => html`<li on-click="ui_shop_clicked:${shop.meta.id}">${shop.content.title}</li>`,
  empty: () => html`<p class="muted">No shops to display.</p>`,
});
registerShopListDirective(true);
```
```html
<ul shop_list></ul>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016t1nbKp6daS49fbfN3NRCC)_